### PR TITLE
Adding CI for Pull Requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: pull_request
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master, dev]
 env:
   DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,17 @@
+name: pull_request
+
+on:
+  pull_request:
+    branches: [ master ]
+env:
+  DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Xcode Build
+      run: |
+        xcodebuild build -workspace COVIDWatch.xcworkspace -scheme 'COVIDWatch iOS' CODE_SIGNING_ALLOWED=NO

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+
+# IntelliJ IDEs
+.idea/


### PR DESCRIPTION
# Motivation

I noticed that an open pull request didn't compile, so I thought it would be good to know if any pull requests fail to compile before they are merged into master.  

The goal of this pull request is to help prevent merging in something that will break the master branch.

## What's in This Pull Request?

This pull request adds a simple [Github Action](https://github.com/features/actions) to build the app on any pull request.

I'm not sure if any CI exists for this repo yet, so let me know if there is a preference for another CI system.  [Github Actions is free for open source repositories](https://github.com/features/actions).

## When Does it Run?

Once this PR is merged to master, this will run an xcodebuild on any new pull request or push to an existing pull request that is targeted to the master branch.

## What Happens Then?

1. Once you put up a PR, you'll notice it is running a status check:

<img width="753" alt="Screen Shot 2020-04-08 at 8 02 59 AM" src="https://user-images.githubusercontent.com/2142301/78783327-75a16c00-7971-11ea-94b1-c003ff7b4801.png">

**NOTE: Notice that right now the merge button is enabled during the status check.  We probably don't want that.**

2. If you click on Details, you will be taken to a Github Actions page to monitor the progress of the build:

<img width="1673" alt="Screen Shot 2020-04-08 at 8 04 20 AM" src="https://user-images.githubusercontent.com/2142301/78783506-bbf6cb00-7971-11ea-98e6-c2bed86d0dc0.png">

3. Once the build passes, you'll see the UI updated for this PR:

<img width="1680" alt="Screen Shot 2020-04-08 at 8 10 35 AM" src="https://user-images.githubusercontent.com/2142301/78783883-548d4b00-7972-11ea-9e73-eabe79797607.png">
<img width="298" alt="Screen Shot 2020-04-08 at 8 10 45 AM" src="https://user-images.githubusercontent.com/2142301/78783678-0710de00-7972-11ea-983a-99ce6e811c65.png">

<img width="771" alt="Screen Shot 2020-04-08 at 8 10 53 AM" src="https://user-images.githubusercontent.com/2142301/78783676-06784780-7972-11ea-9814-94e6c807badd.png">

## Should this prevent merging?

Yes, normally you want to prevent merging in a branch that won't compile.  This setting should be enabled in the repository's settings.  I believe you would need to enable the "require status checks to pass" if you wanted to prevent merging before a pull request has a successful build:

<img width="1031" alt="Screen Shot 2020-04-08 at 8 05 14 AM" src="https://user-images.githubusercontent.com/2142301/78783246-4d197200-7971-11ea-9697-5d51de4c55ea.png">

If this is enabled, nobody will be able to merge a pull request until a successful build has completed. 👍

(I don't have the permission in this repo to add any reviewers)