### PR TITLE
Add observers to user defaults

### DIFF
--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -24,11 +24,11 @@ class Home: BaseViewController {
         super.viewDidLayoutSubviews()
         lastTestedDateObserver = UserDefaults.shared.observe(\.lastTestedDate,
                                                              options: [.initial, .new],
-                                                             changeHandler: { (defaults, change) in
+                                                             changeHandler: { (_, _) in
             self.drawScreen()
         })
-        
-        didUserMakeContactWithSickUserObserver = UserDefaults.shared.observe(\.didUserMakeContactWithSickUser, options: [], changeHandler: { (defaults, change) in
+
+        didUserMakeContactWithSickUserObserver = UserDefaults.shared.observe(\.didUserMakeContactWithSickUser, options: [], changeHandler: { (_, _) in
             self.drawScreen()
         })
         drawScreen()

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -20,8 +20,8 @@ class Home: BaseViewController {
     var lastTestedDateObserver: NSKeyValueObservation?
     var didUserMakeContactWithSickUserObserver: NSKeyValueObservation?
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
+    override func viewDidLoad() {
+        super.viewDidLoad()
         lastTestedDateObserver = UserDefaults.shared.observe(
             \.lastTestedDate,
             options: [.initial, .new],
@@ -35,6 +35,10 @@ class Home: BaseViewController {
             changeHandler: { (_, _) in
             self.drawScreen()
         })
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         drawScreen()
     }
     @objc func test() {

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -38,32 +38,23 @@ class Home: BaseViewController {
         drawScreen()
     }
     @objc func test() {
-//        performSegue(withIdentifier: "test", sender: self)
-//        TODO: Delete below and uncomment above!!!
-        let today = Date()
-        let thirteenDaysBeforeToday = Calendar.current.date(byAdding: .day, value: -13, to: today)!
-        UserDefaults.shared.lastTestedDate = thirteenDaysBeforeToday
+        performSegue(withIdentifier: "test", sender: self)
     }
 
     @objc func share() {
         // text to share
-//        let text = "Become a COVID Watcher and help your community stay safe."
-//        let url = NSURL(string: "https://www.covid-watch.org")
-//
-//        // set up activity view controller
-//        let itemsToShare: [Any] = [ text, url as Any ]
-//        let activityViewController = UIActivityViewController(activityItems: itemsToShare, applicationActivities: nil)
-//
-//        // so that iPads won't crash
-//        activityViewController.popoverPresentationController?.sourceView = self.view
-//
-//        // present the view controller
-//        self.present(activityViewController, animated: true, completion: nil)
-//        TODO: Delete below and uncomment above!!!
-        UserDefaults.shared.didUserMakeContactWithSickUser = !UserDefaults.shared.didUserMakeContactWithSickUser
-        let today = Date()
-        let thirteenDaysBeforeToday = Calendar.current.date(byAdding: .day, value: -15, to: today)!
-        UserDefaults.shared.lastTestedDate = thirteenDaysBeforeToday
+        let text = "Become a COVID Watcher and help your community stay safe."
+        let url = NSURL(string: "https://www.covid-watch.org")
+
+        // set up activity view controller
+        let itemsToShare: [Any] = [ text, url as Any ]
+        let activityViewController = UIActivityViewController(activityItems: itemsToShare, applicationActivities: nil)
+
+        // so that iPads won't crash
+        activityViewController.popoverPresentationController?.sourceView = self.view
+
+        // present the view controller
+        self.present(activityViewController, animated: true, completion: nil)
     }
     // swiftlint:disable:next function_body_length
     private func drawScreen() {

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -61,6 +61,9 @@ class Home: BaseViewController {
 //        self.present(activityViewController, animated: true, completion: nil)
 //        TODO: Delete below and uncomment above!!!
         UserDefaults.shared.didUserMakeContactWithSickUser = !UserDefaults.shared.didUserMakeContactWithSickUser
+        let today = Date()
+        let thirteenDaysBeforeToday = Calendar.current.date(byAdding: .day, value: -15, to: today)!
+        UserDefaults.shared.lastTestedDate = thirteenDaysBeforeToday
     }
     // swiftlint:disable:next function_body_length
     private func drawScreen() {
@@ -160,6 +163,9 @@ class Home: BaseViewController {
                                      top: mainText.frame.maxY,
                                      bottom: testedButtonTop,
                                      centerX: view.center.x)
+            testedButton.isHidden = false
+            testedButton.text.isHidden = false
+            testedButton.subtext?.isHidden = false
         } else {
             testedButton.isHidden = true
             testedButton.text.isHidden = true

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -36,7 +36,7 @@ class Home: BaseViewController {
             changeHandler: { (_, _) in
             self.drawScreen()
         })
-      
+
       // prevent removal of permissions by accident after allowing them
         self.notificationsObserver = NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,
@@ -46,7 +46,7 @@ class Home: BaseViewController {
         }
         self.forceNotificationsEnabled()
     }
-  
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         drawScreen()

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -22,13 +22,17 @@ class Home: BaseViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        lastTestedDateObserver = UserDefaults.shared.observe(\.lastTestedDate,
-                                                             options: [.initial, .new],
-                                                             changeHandler: { (_, _) in
+        lastTestedDateObserver = UserDefaults.shared.observe(
+            \.lastTestedDate,
+            options: [.initial, .new],
+            changeHandler: { (_, _) in
             self.drawScreen()
         })
 
-        didUserMakeContactWithSickUserObserver = UserDefaults.shared.observe(\.didUserMakeContactWithSickUser, options: [], changeHandler: { (_, _) in
+        didUserMakeContactWithSickUserObserver = UserDefaults.shared.observe(
+            \.didUserMakeContactWithSickUser,
+            options: [],
+            changeHandler: { (_, _) in
             self.drawScreen()
         })
         drawScreen()


### PR DESCRIPTION
Added observers to make `Home` respond to changes in `UserDefaults.shared.didUserMakeContactWithSickUser` and `UserDefaults.shared.lastTestedDate`. Additional changes to the `drawScreen()` were necessary to prevent redrawing / other funkiness on state change.

Linter checks are going to be complaining over the TODO's I left in there, which are a result of my incredibly jank method for testing this: I've set it up so that when you click the `spreadButton` it logically not's the `UserDefaults.shared.didUserMakeContactWithSickUser` value and makes the user have been tested 15 days ago, and when you click the `testedButton` it makes the user have been tested 13 days ago. This way you can manually check all the different transitions work properly (just keep clicking the buttons).

You can test that manually yourself, once this PR is approved I'll delete that logic and uncomment the segue logic.