### PR TITLE
Added code for bluetooth permission checking

### DIFF
--- a/COVIDWatch iOS/Bluetooth/BluetoothPermission.swift
+++ b/COVIDWatch iOS/Bluetooth/BluetoothPermission.swift
@@ -9,16 +9,15 @@
 import Foundation
 import CoreBluetooth
 
-typealias BluetoothPermissionCallback = () -> Void
-typealias PermissionResult = Result<Void, BluetoothPermissionError>
+typealias BluetoothPermissionResult = Result<Void, BluetoothPermissionError>
 enum BluetoothPermissionError: String, Error {
     case notAuthorized
 }
 
 class BluetoothPermission: NSObject, CBCentralManagerDelegate {
     var centralManager: CBCentralManager
-    var callback: (PermissionResult) -> Void
-    init(_ callback: @escaping (PermissionResult) -> Void) {
+    var callback: (BluetoothPermissionResult) -> Void
+    init(_ callback: @escaping (BluetoothPermissionResult) -> Void) {
         self.centralManager = CBCentralManager()
         self.callback = callback
         super.init()

--- a/COVIDWatch iOS/Bluetooth/BluetoothPermission.swift
+++ b/COVIDWatch iOS/Bluetooth/BluetoothPermission.swift
@@ -10,40 +10,36 @@ import Foundation
 import CoreBluetooth
 
 typealias BluetoothPermissionCallback = () -> Void
+typealias PermissionResult = Result<Void, BluetoothPermissionError>
+enum BluetoothPermissionError: String, Error {
+    case notAuthorized
+}
 
 class BluetoothPermission: NSObject, CBCentralManagerDelegate {
-    static let sharedInstance = BluetoothPermission()
-    override private init() {}
-    var centralManager: CBCentralManager?
-    var allowed: BluetoothPermissionCallback?
-    var denied: BluetoothPermissionCallback?
-
-    func checkPermission(_ allowed: @escaping () -> Void, _ denied: @escaping () -> Void) {
+    var centralManager: CBCentralManager
+    var callback: (PermissionResult) -> Void
+    init(_ callback: @escaping (PermissionResult) -> Void) {
         self.centralManager = CBCentralManager()
-        self.allowed = allowed
-        self.denied = denied
-        self.centralManager?.delegate = self
+        self.callback = callback
+        super.init()
+        self.centralManager.delegate = self
     }
 
     var isAuthorized: Bool {
+        if #available(iOS 13.1, *) {
+            return CBCentralManager.authorization == .allowedAlways
+        }
         if #available(iOS 13.0, *) {
-            return self.centralManager?.authorization == .allowedAlways
+            return self.centralManager.authorization == .allowedAlways
         }
         return CBPeripheralManager.authorizationStatus() == .authorized
     }
 
-    func clearCallbacks() {
-        self.allowed = nil
-        self.denied = nil
-    }
-
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         if self.isAuthorized {
-            BluetoothPermission.sharedInstance.allowed?()
-            self.clearCallbacks()
+            self.callback(Result.success(()))
         } else {
-            BluetoothPermission.sharedInstance.denied?()
-            self.clearCallbacks()
+            self.callback(.failure(.notAuthorized))
         }
     }
 }

--- a/COVIDWatch iOS/Bluetooth/BluetoothPermission.swift
+++ b/COVIDWatch iOS/Bluetooth/BluetoothPermission.swift
@@ -1,0 +1,49 @@
+//
+//  BluetoothPermission.swift
+//  COVIDWatch iOS
+//
+//  Created by Madhava Jay on 13/4/20.
+//  Copyright © 2020 IZE. All rights reserved.
+//
+
+import Foundation
+import CoreBluetooth
+
+typealias BluetoothPermissionCallback = () -> Void
+
+class BluetoothPermission: NSObject, CBCentralManagerDelegate {
+    static let sharedInstance = BluetoothPermission()
+    override private init() {}
+    var centralManager: CBCentralManager?
+    var allowed: BluetoothPermissionCallback?
+    var denied: BluetoothPermissionCallback?
+
+    func checkPermission(_ allowed: @escaping () -> Void, _ denied: @escaping () -> Void) {
+        self.centralManager = CBCentralManager()
+        self.allowed = allowed
+        self.denied = denied
+        self.centralManager?.delegate = self
+    }
+
+    var isAuthorized: Bool {
+        if #available(iOS 13.0, *) {
+            return self.centralManager?.authorization == .allowedAlways
+        }
+        return CBPeripheralManager.authorizationStatus() == .authorized
+    }
+
+    func clearCallbacks() {
+        self.allowed = nil
+        self.denied = nil
+    }
+
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        if self.isAuthorized {
+            BluetoothPermission.sharedInstance.allowed?()
+            self.clearCallbacks()
+        } else {
+            BluetoothPermission.sharedInstance.denied?()
+            self.clearCallbacks()
+        }
+    }
+}

--- a/COVIDWatch iOS/Utility/NotificationPermission.swift
+++ b/COVIDWatch iOS/Utility/NotificationPermission.swift
@@ -1,0 +1,35 @@
+//
+//  NotificationPermission.swift
+//  COVIDWatch iOS
+//
+//  Created by Madhava Jay on 14/4/20.
+//  Copyright © 2020 IZE. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+typealias NotificationPermissionResult = Result<Void, NotificationPermissionError>
+enum NotificationPermissionError: Error {
+    case notAuthorized
+    case failedWithError(_ error: Error)
+}
+
+struct NotificationPermission {
+    init(permissions: UNAuthorizationOptions = [.alert, .sound, .badge],
+         _ callback: @escaping (NotificationPermissionResult) -> Void
+    ) {
+        UNUserNotificationCenter.current().requestAuthorization(
+            options: permissions
+        ) { granted, error in
+            if let error = error {
+                callback(.failure(.failedWithError(error)))
+                return
+            } else if !granted {
+                callback(.failure(.notAuthorized))
+            } else {
+                callback(.success(()))
+            }
+        }
+    }
+}

--- a/COVIDWatch iOS/ViewControllers/Bluetooth.swift
+++ b/COVIDWatch iOS/ViewControllers/Bluetooth.swift
@@ -15,6 +15,7 @@ class Bluetooth: BaseViewController {
     var mainText = MainText(text: "We use Bluetooth to anonymously log interactions with other Covid Watch users. Your personal data is always private and never shared.")
     var button = Button(text: "Allow Bluetooth", subtext: "This is required for the app to work.")
 
+    var buttonRecognizer: UITapGestureRecognizer?
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         self.view.backgroundColor = UIColor(hexString: "FFFFFF")
@@ -34,19 +35,45 @@ class Bluetooth: BaseViewController {
                        originY: img.frame.maxY + 20 * figmaToiOSVerticalScalingFactor)
 
         mainText.draw(parentVC: self, centerX: view.center.x, originY: largeText.frame.maxY)
-
-        self.button.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.nextScreen)))
+        self.buttonRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.nextScreen))
+        if let buttonRecognizer = self.buttonRecognizer {
+            self.button.addGestureRecognizer(buttonRecognizer)
+        }
         let buttonTop: CGFloat = 668.0 * figmaToiOSVerticalScalingFactor
         button.draw(parentVC: self, centerX: view.center.x, originY: buttonTop)
     }
 
     @objc func nextScreen(sender: UITapGestureRecognizer) {
         if sender.state == .ended {
-            if UserDefaults.standard.isContactEventLoggingEnabled == false {
-                UserDefaults.standard.isContactEventLoggingEnabled = true
+            self.buttonRecognizer?.isEnabled = false // disable double tap
+            BluetoothPermission.sharedInstance.checkPermission({ [weak self] in
+                self?.buttonRecognizer?.isEnabled = true
 
-            }
-            performSegue(withIdentifier: "BluetoothToNotifications", sender: self)
+                if UserDefaults.standard.isContactEventLoggingEnabled == false {
+                    UserDefaults.standard.isContactEventLoggingEnabled = true
+                }
+                self?.performSegue(withIdentifier: "BluetoothToNotifications", sender: self)
+            }, {
+                self.buttonRecognizer?.isEnabled = true
+
+                let bluetoothSettingsAlert = UIAlertController(
+                    title: NSLocalizedString("Bluetooth Required", comment: ""),
+                    message: "Please turn on Bluetooth in Settings", preferredStyle: .alert
+                )
+                bluetoothSettingsAlert.addAction(
+                    UIAlertAction(
+                        title: NSLocalizedString("Open Settings", comment: ""),
+                        style: .default,
+                        handler: { _ in
+                            if let url = URL(string: UIApplication.openSettingsURLString) {
+                                UIApplication.shared.open(url)
+                            }
+                        }
+                    )
+                )
+                self.present(bluetoothSettingsAlert, animated: true)
+                print("Please go into settings and enable Bluetooth")
+            })
         }
     }
 

--- a/COVIDWatch iOS/ViewControllers/Bluetooth.swift
+++ b/COVIDWatch iOS/ViewControllers/Bluetooth.swift
@@ -16,6 +16,8 @@ class Bluetooth: BaseViewController {
     var button = Button(text: "Allow Bluetooth", subtext: "This is required for the app to work.")
 
     var buttonRecognizer: UITapGestureRecognizer?
+    var bluetoothPermission: BluetoothPermission?
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         self.view.backgroundColor = UIColor(hexString: "FFFFFF")
@@ -46,34 +48,37 @@ class Bluetooth: BaseViewController {
     @objc func nextScreen(sender: UITapGestureRecognizer) {
         if sender.state == .ended {
             self.buttonRecognizer?.isEnabled = false // disable double tap
-            BluetoothPermission.sharedInstance.checkPermission({ [weak self] in
-                self?.buttonRecognizer?.isEnabled = true
+            self.bluetoothPermission = BluetoothPermission { [weak self] (result) in
+                switch result {
+                case .success:
+                    self?.buttonRecognizer?.isEnabled = true
 
-                if UserDefaults.standard.isContactEventLoggingEnabled == false {
-                    UserDefaults.standard.isContactEventLoggingEnabled = true
-                }
-                self?.performSegue(withIdentifier: "BluetoothToNotifications", sender: self)
-            }, {
-                self.buttonRecognizer?.isEnabled = true
+                    if UserDefaults.standard.isContactEventLoggingEnabled == false {
+                        UserDefaults.standard.isContactEventLoggingEnabled = true
+                    }
+                    self?.performSegue(withIdentifier: "BluetoothToNotifications", sender: self)
+                case .failure:
+                    self?.buttonRecognizer?.isEnabled = true
 
-                let bluetoothSettingsAlert = UIAlertController(
-                    title: NSLocalizedString("Bluetooth Required", comment: ""),
-                    message: "Please turn on Bluetooth in Settings", preferredStyle: .alert
-                )
-                bluetoothSettingsAlert.addAction(
-                    UIAlertAction(
-                        title: NSLocalizedString("Open Settings", comment: ""),
-                        style: .default,
-                        handler: { _ in
-                            if let url = URL(string: UIApplication.openSettingsURLString) {
-                                UIApplication.shared.open(url)
-                            }
-                        }
+                    let bluetoothSettingsAlert = UIAlertController(
+                        title: NSLocalizedString("Bluetooth Required", comment: ""),
+                        message: "Please turn on Bluetooth in Settings", preferredStyle: .alert
                     )
-                )
-                self.present(bluetoothSettingsAlert, animated: true)
-                print("Please go into settings and enable Bluetooth")
-            })
+                    bluetoothSettingsAlert.addAction(
+                        UIAlertAction(
+                            title: NSLocalizedString("Open Settings", comment: ""),
+                            style: .default,
+                            handler: { _ in
+                                if let url = URL(string: UIApplication.openSettingsURLString) {
+                                    UIApplication.shared.open(url)
+                                }
+                            }
+                        )
+                    )
+                    self?.present(bluetoothSettingsAlert, animated: true)
+                    print("Please go into settings and enable Bluetooth")
+                }
+            }
         }
     }
 

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -38,13 +38,14 @@ class Home: BaseViewController {
         ) { [weak self] _ in
             self?.checkBluetoothPermission()
         }
+        self.checkBluetoothPermission()
     }
 
     func checkBluetoothPermission() {
         BluetoothPermission.sharedInstance.checkPermission({
             // nothing to do
             print("Bluetooth is still enabled")
-        }, {
+        }, { [weak self] in
             // can also change the home page to visually inform the user that bluetooth is not enabled
             let bluetoothSettingsAlert = UIAlertController(
                 title: NSLocalizedString("Bluetooth Required", comment: ""),
@@ -61,7 +62,7 @@ class Home: BaseViewController {
                     }
                 )
             )
-            self.present(bluetoothSettingsAlert, animated: true)
+            self?.present(bluetoothSettingsAlert, animated: true)
         })
     }
 

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -19,6 +19,8 @@ class Home: BaseViewController {
     var infoBanner = InfoBanner(text: "You may have been in contact with COVID-19")
     var notificationsObserver: NSObjectProtocol?
 
+    var observer: NSObjectProtocol?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         // prevent removal of permissions by accident after allowing them
@@ -30,6 +32,39 @@ class Home: BaseViewController {
         }
         self.forceNotificationsEnabled()
     }
+        self.observer = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil, queue: OperationQueue.main
+        ) { [weak self] _ in
+            self?.checkBluetoothPermission()
+        }
+    }
+
+    func checkBluetoothPermission() {
+        BluetoothPermission.sharedInstance.checkPermission({
+            // nothing to do
+            print("Bluetooth is still enabled")
+        }, {
+            // can also change the home page to visually inform the user that bluetooth is not enabled
+            let bluetoothSettingsAlert = UIAlertController(
+                title: NSLocalizedString("Bluetooth Required", comment: ""),
+                message: "Please turn on Bluetooth in Settings", preferredStyle: .alert
+            )
+            bluetoothSettingsAlert.addAction(
+                UIAlertAction(
+                    title: NSLocalizedString("Open Settings", comment: ""),
+                    style: .default,
+                    handler: { _ in
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    }
+                )
+            )
+            self.present(bluetoothSettingsAlert, animated: true)
+        })
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         drawScreen()

--- a/COVIDWatch.xcodeproj/project.pbxproj
+++ b/COVIDWatch.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		B1D85F9E809BCC12318E2223 /* Pods_COVIDWatch_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 067227CBFA80D8CE4D90B6F6 /* Pods_COVIDWatch_iOS.framework */; };
 		E1A7016D243D448F001FF6F0 /* ThankYou.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A7016A243D448F001FF6F0 /* ThankYou.swift */; };
 		E1C729FF243DE30900D30118 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C729FE243DE30900D30118 /* Test.swift */; };
+		E24BC323244545CB00819EF0 /* NotificationPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24BC322244545CB00819EF0 /* NotificationPermission.swift */; };
 		E2B451A924443FE900E17888 /* BluetoothPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B451A824443FE900E17888 /* BluetoothPermission.swift */; };
 		F59A36E1AD0F8E40375BE630 /* Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B100AAFD7EDE7205A094091D /* Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework */; };
 /* End PBXBuildFile section */
@@ -193,6 +194,7 @@
 		B100AAFD7EDE7205A094091D /* Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1A7016A243D448F001FF6F0 /* ThankYou.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThankYou.swift; sourceTree = "<group>"; };
 		E1C729FE243DE30900D30118 /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
+		E24BC322244545CB00819EF0 /* NotificationPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermission.swift; sourceTree = "<group>"; };
 		E2B451A824443FE900E17888 /* BluetoothPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothPermission.swift; sourceTree = "<group>"; };
 		ECF661F853918EA18D1C729B /* Pods-COVIDWatch iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-COVIDWatch iOSTests.debug.xcconfig"; path = "Target Support Files/Pods-COVIDWatch iOSTests/Pods-COVIDWatch iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -286,6 +288,7 @@
 				2EF61C382436F82D003046A4 /* UIColorExtension.swift */,
 				2EBF8728243BCFA1003278E6 /* UIViewExtension.swift */,
 				2EFE6307243FB54F00D00305 /* UIResponderExtension.swift */,
+				E24BC322244545CB00819EF0 /* NotificationPermission.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -782,6 +785,7 @@
 				2EBF8735243CE60E003278E6 /* Menu.swift in Sources */,
 				E1A7016D243D448F001FF6F0 /* ThankYou.swift in Sources */,
 				2EFE6308243FB54F00D00305 /* UIResponderExtension.swift in Sources */,
+				E24BC323244545CB00819EF0 /* NotificationPermission.swift in Sources */,
 				2EFE6304243F990900D00305 /* Home.swift in Sources */,
 				2DF8F3D32430C503001C88EF /* AppDelegate+BackgroundFetch.swift in Sources */,
 				2DF8F3D1243082F7001C88EF /* AppDelegate+BackgroundTasks.swift in Sources */,

--- a/COVIDWatch.xcodeproj/project.pbxproj
+++ b/COVIDWatch.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		B1D85F9E809BCC12318E2223 /* Pods_COVIDWatch_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 067227CBFA80D8CE4D90B6F6 /* Pods_COVIDWatch_iOS.framework */; };
 		E1A7016D243D448F001FF6F0 /* ThankYou.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A7016A243D448F001FF6F0 /* ThankYou.swift */; };
 		E1C729FF243DE30900D30118 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C729FE243DE30900D30118 /* Test.swift */; };
+		E2B451A924443FE900E17888 /* BluetoothPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B451A824443FE900E17888 /* BluetoothPermission.swift */; };
 		F59A36E1AD0F8E40375BE630 /* Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B100AAFD7EDE7205A094091D /* Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework */; };
 /* End PBXBuildFile section */
 
@@ -192,6 +193,7 @@
 		B100AAFD7EDE7205A094091D /* Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1A7016A243D448F001FF6F0 /* ThankYou.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThankYou.swift; sourceTree = "<group>"; };
 		E1C729FE243DE30900D30118 /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
+		E2B451A824443FE900E17888 /* BluetoothPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothPermission.swift; sourceTree = "<group>"; };
 		ECF661F853918EA18D1C729B /* Pods-COVIDWatch iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-COVIDWatch iOSTests.debug.xcconfig"; path = "Target Support Files/Pods-COVIDWatch iOSTests/Pods-COVIDWatch iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -256,6 +258,7 @@
 				2DB09A3C2419873A0049CD2A /* BluetoothService+CoreBluetooth.swift */,
 				2DB09A3A24197A7C0049CD2A /* BluetoothController.swift */,
 				2D6655AD242BF9A300B462E0 /* BluetoothController+ContactEvent.swift */,
+				E2B451A824443FE900E17888 /* BluetoothPermission.swift */,
 			);
 			path = Bluetooth;
 			sourceTree = "<group>";
@@ -762,6 +765,7 @@
 				2DC231EA241B949300216404 /* CurrentUserExposureNotifier.swift in Sources */,
 				2EF61C392436F82D003046A4 /* UIColorExtension.swift in Sources */,
 				2EBF8725243BC275003278E6 /* Header.swift in Sources */,
+				E2B451A924443FE900E17888 /* BluetoothPermission.swift in Sources */,
 				2EBF8727243BC7F8003278E6 /* BaseViewController.swift in Sources */,
 				2EFE630C2440E9EA00D00305 /* InfoBanner.swift in Sources */,
 				2DDEBF5E241A3468005BE9A8 /* PersistentContainer.swift in Sources */,


### PR DESCRIPTION
- Code runs on bluetooth page during onboarding
- Code also runs on main page when viewDidLoad
- App crash with SIG 9 is expected when changing BT settings mid app
  See: https://stackoverflow.com/questions/42331852/quitting-app-causes-error-message-from-debugger-terminated-due-to-signal-9

See Images:
https://imgur.com/a/HgfqdpT

To test, there are three states:
1) First Install approved
- everything goes as normal (happy path)
2) First Install denied
- user does not approve bluetooth and cannot continue onboarding
- this will force you to go settings but the app will restart if you change see above
3) Home Screen
- you can only get here with approved bluetooth
4) Home Screen (change setting in background)
- you can change the setting in the background and this will alert you on loading home 