### PR TITLE
Forcing deep clone for merge

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: master
+        fetch-depth: 0
     - name: Merge Dev into Master
       run: |
         git checkout dev 


### PR DESCRIPTION
The merge to master to trigger TestFlight builds is failing because it can't find dev.  This change will force that job to do a deep clone to be able to merge dev into master.