### PR TITLE
Components get weak ref to parent vc

### DIFF
--- a/COVIDWatch iOS/UIComponents/BaseUIComponent.swift
+++ b/COVIDWatch iOS/UIComponents/BaseUIComponent.swift
@@ -1,0 +1,9 @@
+//
+//  BaseUIComponent.swift
+//  COVIDWatch iOS
+//
+//  Created by Isaiah Becker-Mayer on 4/18/20.
+//  Copyright © 2020 IZE. All rights reserved.
+//
+
+import Foundation

--- a/COVIDWatch iOS/UIComponents/Button.swift
+++ b/COVIDWatch iOS/UIComponents/Button.swift
@@ -9,10 +9,12 @@
 import UIKit
 
 class Button: UIView {
+    weak var parentVC: BaseViewController?
     var text = UILabel()
     var subtext: UITextView?
 
-    init(text: String, subtext: String? = nil) {
+    init(_ parentVC: BaseViewController, text: String, subtext: String? = nil) {
+        self.parentVC = parentVC
         super.init(frame: CGRect())
         self.text.text = text
         if subtext != nil {
@@ -44,46 +46,44 @@ class Button: UIView {
     }
 
 //    Call this after you set where you want to place your button in the parentVC
-    func draw(parentVC: UIViewController, centerX: CGFloat, centerY: CGFloat) {
-
+    func draw(centerX: CGFloat, centerY: CGFloat) {
         self.center.x = centerX
         self.center.y = centerY
-        parentVC.view.addSubview(self)
-        drawText(parentVC: parentVC)
+        parentVC?.view.addSubview(self)
+        drawText()
     }
 
-    func draw(parentVC: UIViewController, centerX: CGFloat, originY: CGFloat) {
-
+    func draw(centerX: CGFloat, originY: CGFloat) {
         self.center.x = centerX
         self.frame.origin.y = originY
-        parentVC.view.addSubview(self)
-        drawText(parentVC: parentVC)
+        parentVC?.view.addSubview(self)
+        drawText()
     }
 
-    func drawText(parentVC: UIViewController) {
+    func drawText() {
 //        Call after the button's container has been laid out in parent ViewController
         self.text.sizeToFit()
         self.text.center = self.center
-        parentVC.view.addSubview(self.text)
+        parentVC?.view.addSubview(self.text)
         self.subtext?.frame.size.width = contentMaxWidth
         self.subtext?.frame.size.height = self.subtext?.contentSize.height ?? 0
         self.subtext?.center.x = self.text.center.x
         self.subtext?.frame.origin.y = self.frame.maxY
         if let subtext = self.subtext {
-            parentVC.view.addSubview(subtext)
+            parentVC?.view.addSubview(subtext)
         }
         self.subtext?.isSelectable = false
     }
 
-    func drawBetween(parentVC: UIViewController, top: CGFloat, bottom: CGFloat, centerX: CGFloat) {
+    func drawBetween(top: CGFloat, bottom: CGFloat, centerX: CGFloat) {
 //        Draw the button so that it and its subtext taken together are
 //        centered between top and bottom
-        self.draw(parentVC: parentVC, centerX: centerX, centerY: (top+bottom)/2)
-        if let selfSubtext = self.subtext {
-            let adjustment = (selfSubtext.frame.maxY - self.frame.maxY) / 2
+        self.draw(centerX: centerX, centerY: (top+bottom)/2)
+        if let subtext = self.subtext {
+            let adjustment = (subtext.frame.maxY - self.frame.maxY) / 2
             self.center.y -= adjustment
             self.text.center.y -= adjustment
-            selfSubtext.center.y -= adjustment
+            subtext.center.y -= adjustment
         }
     }
 

--- a/COVIDWatch iOS/UIComponents/Button.swift
+++ b/COVIDWatch iOS/UIComponents/Button.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class Button: UIView {
-    weak var parentVC: BaseViewController?
+    weak var parentVC: BaseViewController!
     var text = UILabel()
     var subtext: UITextView?
 
@@ -49,14 +49,14 @@ class Button: UIView {
     func draw(centerX: CGFloat, centerY: CGFloat) {
         self.center.x = centerX
         self.center.y = centerY
-        parentVC?.view.addSubview(self)
+        parentVC.view.addSubview(self)
         drawText()
     }
 
     func draw(centerX: CGFloat, originY: CGFloat) {
         self.center.x = centerX
         self.frame.origin.y = originY
-        parentVC?.view.addSubview(self)
+        parentVC.view.addSubview(self)
         drawText()
     }
 
@@ -64,13 +64,13 @@ class Button: UIView {
 //        Call after the button's container has been laid out in parent ViewController
         self.text.sizeToFit()
         self.text.center = self.center
-        parentVC?.view.addSubview(self.text)
+        parentVC.view.addSubview(self.text)
         self.subtext?.frame.size.width = contentMaxWidth
         self.subtext?.frame.size.height = self.subtext?.contentSize.height ?? 0
         self.subtext?.center.x = self.text.center.x
         self.subtext?.frame.origin.y = self.frame.maxY
         if let subtext = self.subtext {
-            parentVC?.view.addSubview(subtext)
+            parentVC.view.addSubview(subtext)
         }
         self.subtext?.isSelectable = false
     }

--- a/COVIDWatch iOS/UIComponents/Header.swift
+++ b/COVIDWatch iOS/UIComponents/Header.swift
@@ -37,22 +37,22 @@ class Header: UIView {
         self.frame.size.height = screenHeight * 0.1
     }
 
-    func draw(parentVC: UIViewController) {
-        self.frame.origin.y = parentVC.view.safeAreaInsets.top
-        drawLogo(parentVC: parentVC)
-        drawMenuIcon(parentVC: parentVC)
+    func draw() {
+        self.frame.origin.y = parentVC?.view.safeAreaInsets.top ?? 0
+        drawLogo()
+        drawMenuIcon()
     }
 
-    private func drawLogo(parentVC: UIViewController) {
+    private func drawLogo() {
         logo.frame.size.width = 35
         logo.frame.size.height = 35
 //        line up logo with the rest of the left hand content
         logo.frame.origin.x = (screenWidth - contentMaxWidth) / 2
         logo.center.y = self.frame.midY
-        parentVC.view.addSubview(logo)
+        parentVC?.view.addSubview(logo)
     }
 
-    private func drawMenuIcon(parentVC: UIViewController) {
+    private func drawMenuIcon() {
         menuIcon.frame.size.width = 36
         menuIcon.frame.size.height = 25
 //        line up menu icon with the rest of the right hand content
@@ -61,8 +61,8 @@ class Header: UIView {
         menuIcon.center.y = self.frame.midY
         menuIcon.isUserInteractionEnabled = true
         menuIcon.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.toggleMenu)))
-        parentVC.view.addSubview(menuIcon)
-        parentVC.view.bringSubviewToFront(menuIcon)
+        parentVC?.view.addSubview(menuIcon)
+        parentVC?.view.bringSubviewToFront(menuIcon)
     }
 
     @objc func toggleMenu() {

--- a/COVIDWatch iOS/UIComponents/Header.swift
+++ b/COVIDWatch iOS/UIComponents/Header.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class Header: UIView {
-    weak var parentVC: BaseViewController?
+    weak var parentVC: BaseViewController!
     var logo = UIImageView(image: UIImage(named: "logo-cw-color"))
     var menuIcon = UIImageView(image: UIImage(named: "menu-icon"))
     var menu: Menu?
@@ -38,7 +38,7 @@ class Header: UIView {
     }
 
     func draw() {
-        self.frame.origin.y = parentVC?.view.safeAreaInsets.top ?? 0
+        self.frame.origin.y = parentVC.view.safeAreaInsets.top
         drawLogo()
         drawMenuIcon()
     }
@@ -49,7 +49,7 @@ class Header: UIView {
 //        line up logo with the rest of the left hand content
         logo.frame.origin.x = (screenWidth - contentMaxWidth) / 2
         logo.center.y = self.frame.midY
-        parentVC?.view.addSubview(logo)
+        parentVC.view.addSubview(logo)
     }
 
     private func drawMenuIcon() {
@@ -61,8 +61,8 @@ class Header: UIView {
         menuIcon.center.y = self.frame.midY
         menuIcon.isUserInteractionEnabled = true
         menuIcon.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.toggleMenu)))
-        parentVC?.view.addSubview(menuIcon)
-        parentVC?.view.bringSubviewToFront(menuIcon)
+        parentVC.view.addSubview(menuIcon)
+        parentVC.view.bringSubviewToFront(menuIcon)
     }
 
     @objc func toggleMenu() {

--- a/COVIDWatch iOS/UIComponents/InfoBanner.swift
+++ b/COVIDWatch iOS/UIComponents/InfoBanner.swift
@@ -9,19 +9,21 @@
 import UIKit
 
 class InfoBanner: UIView {
-    var text: UITextView?
+    weak var parentVC: BaseViewController?
+    var text = UITextView()
     var isInteractive: Bool = false
     let exclamationCircle = UIImageView(image: UIImage(named: "exclamation-circle"))
     let buttonArrow = UIImageView(image: UIImage(named: "button-arrow"))
     private var _onClick: () -> Void = {return}
-    init(text: String, onClick: @escaping () -> Void) {
+    init(_ parentVC: BaseViewController, text: String, onClick: @escaping () -> Void) {
+        self.parentVC = parentVC
         self._onClick = onClick
         super.init(frame: CGRect())
-
+        
         self.frame.size.width = screenWidth
         self.frame.size.height = 100 * figmaToiOSVerticalScalingFactor
         self.backgroundColor = UIColor.Secondary.Tangerine
-
+        
         self.text = UITextView()
         var fontSize: CGFloat = 18
         if screenHeight <= 568 {
@@ -29,22 +31,20 @@ class InfoBanner: UIView {
         } else if screenHeight <= 667 {
             fontSize = 16
         }
-        if let selfText = self.text {
-            selfText.text = text
-            selfText.font = UIFont(name: "Montserrat-Bold", size: fontSize)
-            selfText.textColor = .white
-            selfText.isEditable = false
-            selfText.isSelectable = false
-            selfText.backgroundColor = .clear
-        }
-
+        self.text.text = text
+        self.text.font = UIFont(name: "Montserrat-Bold", size: fontSize)
+        self.text.textColor = .white
+        self.text.isEditable = false
+        self.text.isSelectable = false
+        self.text.backgroundColor = .clear
+        
         self.addGestureRecognizer(
             UITapGestureRecognizer(
                 target: self,
                 action: #selector(self.onClick)
             )
         )
-        self.text?.addGestureRecognizer(
+        self.text.addGestureRecognizer(
             UITapGestureRecognizer(
                 target: self,
                 action: #selector(self.onClick)
@@ -63,51 +63,47 @@ class InfoBanner: UIView {
             )
         )
     }
-
-    func draw(parentVC: UIViewController, centerX: CGFloat, originY: CGFloat) {
+    
+    func draw(centerX: CGFloat, originY: CGFloat) {
         self.center.x = centerX
         self.frame.origin.y = originY
-        if let selfText = self.text {
-            selfText.center.x = self.center.x
-            selfText.center.y = self.center.y
-            if isInteractive {
-                selfText.frame.size.width = 250 * figmaToiOSHorizontalScalingFactor
-            } else {
-                selfText.frame.size.width = 290 * figmaToiOSHorizontalScalingFactor
-            }
-            selfText.frame.size.height = selfText.contentSize.height
-            selfText.backgroundColor = .clear
+        text.center.x = self.center.x
+        text.center.y = self.center.y
+        if isInteractive {
+            text.frame.size.width = 250 * figmaToiOSHorizontalScalingFactor
+        } else {
+            text.frame.size.width = 290 * figmaToiOSHorizontalScalingFactor
         }
+        text.frame.size.height = text.contentSize.height
+        text.backgroundColor = .clear
         if isInteractive {
             self.exclamationCircle.isHidden = false
             self.exclamationCircle.frame.size.width = 35.0 * figmaToiOSHorizontalScalingFactor
             self.exclamationCircle.frame.size.height = self.exclamationCircle.frame.size.width
             //swiftlint:disable:next line_length
-            self.exclamationCircle.frame.origin.x = (self.text?.frame.origin.x ?? 0) - self.exclamationCircle.frame.size.width - (15 * figmaToiOSHorizontalScalingFactor)
-            self.exclamationCircle.center.y = self.text?.center.y ?? 0
+            self.exclamationCircle.frame.origin.x = self.text.frame.origin.x - self.exclamationCircle.frame.size.width - (15 * figmaToiOSHorizontalScalingFactor)
+            self.exclamationCircle.center.y = self.text.center.y
             self.buttonArrow.isHidden = false
             self.buttonArrow.frame.size.height = 24 * figmaToiOSVerticalScalingFactor
             self.buttonArrow.frame.size.width = (13.33/24.0) * self.buttonArrow.frame.size.height
-            self.buttonArrow.center.y = self.text?.center.y ?? 0
+            self.buttonArrow.center.y = self.text.center.y
             //swiftlint:disable:next line_length
-            self.buttonArrow.frame.origin.x = (self.text?.frame.origin.x ?? 0) + (self.text?.frame.size.width ?? 0) + 18 * figmaToiOSHorizontalScalingFactor
+            self.buttonArrow.frame.origin.x = self.text.frame.origin.x + self.text.frame.size.width + 18 * figmaToiOSHorizontalScalingFactor
         } else {
             self.exclamationCircle.isHidden = true
             self.buttonArrow.isHidden = true
         }
-
-        parentVC.view.addSubview(self)
-        if let selfText = self.text {
-            parentVC.view.addSubview(selfText)
-        }
-        parentVC.view.addSubview(self.exclamationCircle)
-        parentVC.view.addSubview(self.buttonArrow)
+        
+        parentVC?.view.addSubview(self)
+        parentVC?.view.addSubview(text)
+        parentVC?.view.addSubview(self.exclamationCircle)
+        parentVC?.view.addSubview(self.buttonArrow)
     }
-
+    
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-
+    
     @objc func onClick() {
         if isInteractive {
             self._onClick()

--- a/COVIDWatch iOS/UIComponents/InfoBanner.swift
+++ b/COVIDWatch iOS/UIComponents/InfoBanner.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class InfoBanner: UIView {
-    weak var parentVC: BaseViewController?
+    weak var parentVC: BaseViewController!
     var text = UITextView()
     var isInteractive: Bool = false
     let exclamationCircle = UIImageView(image: UIImage(named: "exclamation-circle"))
@@ -94,10 +94,10 @@ class InfoBanner: UIView {
             self.buttonArrow.isHidden = true
         }
         
-        parentVC?.view.addSubview(self)
-        parentVC?.view.addSubview(text)
-        parentVC?.view.addSubview(self.exclamationCircle)
-        parentVC?.view.addSubview(self.buttonArrow)
+        parentVC.view.addSubview(self)
+        parentVC.view.addSubview(text)
+        parentVC.view.addSubview(self.exclamationCircle)
+        parentVC.view.addSubview(self.buttonArrow)
     }
     
     required init?(coder: NSCoder) {

--- a/COVIDWatch iOS/UIComponents/InfoBanner.swift
+++ b/COVIDWatch iOS/UIComponents/InfoBanner.swift
@@ -67,14 +67,14 @@ class InfoBanner: UIView {
     func draw(centerX: CGFloat, originY: CGFloat) {
         self.center.x = centerX
         self.frame.origin.y = originY
-        text.center.x = self.center.x
-        text.center.y = self.center.y
         if isInteractive {
             text.frame.size.width = 250 * figmaToiOSHorizontalScalingFactor
         } else {
             text.frame.size.width = 290 * figmaToiOSHorizontalScalingFactor
         }
         text.frame.size.height = text.contentSize.height
+        text.center.x = self.center.x
+        text.center.y = self.center.y
         text.backgroundColor = .clear
         if isInteractive {
             self.exclamationCircle.isHidden = false
@@ -95,7 +95,7 @@ class InfoBanner: UIView {
         }
         
         parentVC.view.addSubview(self)
-        parentVC.view.addSubview(text)
+        parentVC.view.addSubview(self.text)
         parentVC.view.addSubview(self.exclamationCircle)
         parentVC.view.addSubview(self.buttonArrow)
     }

--- a/COVIDWatch iOS/UIComponents/LargeText.swift
+++ b/COVIDWatch iOS/UIComponents/LargeText.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class LargeText: UITextView {
-    weak var parentVC: BaseViewController?
+    weak var parentVC: BaseViewController!
     init(_ parentVC: BaseViewController, text: String) {
         self.parentVC = parentVC
         super.init(frame: CGRect(), textContainer: nil)
@@ -32,13 +32,13 @@ class LargeText: UITextView {
     func draw(centerX: CGFloat, centerY: CGFloat) {
         self.center.x = centerX
         self.center.y = centerY
-        parentVC?.view.addSubview(self)
+        parentVC.view.addSubview(self)
     }
 
     func draw(centerX: CGFloat, originY: CGFloat) {
         self.center.x = centerX
         self.frame.origin.y = originY
-        parentVC?.view.addSubview(self)
+        parentVC.view.addSubview(self)
     }
 
     required init?(coder: NSCoder) {

--- a/COVIDWatch iOS/UIComponents/LargeText.swift
+++ b/COVIDWatch iOS/UIComponents/LargeText.swift
@@ -9,7 +9,9 @@
 import UIKit
 
 class LargeText: UITextView {
-    init(text: String) {
+    weak var parentVC: BaseViewController?
+    init(_ parentVC: BaseViewController, text: String) {
+        self.parentVC = parentVC
         super.init(frame: CGRect(), textContainer: nil)
         self.text = text
         var fontSize: CGFloat = 36
@@ -27,16 +29,16 @@ class LargeText: UITextView {
         self.isSelectable = false
     }
 
-    func draw(parentVC: UIViewController, centerX: CGFloat, centerY: CGFloat) {
+    func draw(centerX: CGFloat, centerY: CGFloat) {
         self.center.x = centerX
         self.center.y = centerY
-        parentVC.view.addSubview(self)
+        parentVC?.view.addSubview(self)
     }
 
-    func draw(parentVC: UIViewController, centerX: CGFloat, originY: CGFloat) {
+    func draw(centerX: CGFloat, originY: CGFloat) {
         self.center.x = centerX
         self.frame.origin.y = originY
-        parentVC.view.addSubview(self)
+        parentVC?.view.addSubview(self)
     }
 
     required init?(coder: NSCoder) {

--- a/COVIDWatch iOS/UIComponents/MainText.swift
+++ b/COVIDWatch iOS/UIComponents/MainText.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class MainText: UITextView {
-    weak var parentVC: BaseViewController?
+    weak var parentVC: BaseViewController!
     
     init(_ parentVC: BaseViewController, text: String) {
         self.parentVC = parentVC
@@ -35,7 +35,7 @@ class MainText: UITextView {
         self.frame.size.height = self.contentSize.height
         self.center.x = centerX
         self.frame.origin.y = originY
-        parentVC?.view.addSubview(self)
+        parentVC.view.addSubview(self)
     }
 
     required init?(coder: NSCoder) {

--- a/COVIDWatch iOS/UIComponents/MainText.swift
+++ b/COVIDWatch iOS/UIComponents/MainText.swift
@@ -9,7 +9,10 @@
 import UIKit
 
 class MainText: UITextView {
-    init(text: String) {
+    weak var parentVC: BaseViewController?
+    
+    init(_ parentVC: BaseViewController, text: String) {
+        self.parentVC = parentVC
         super.init(frame: CGRect(), textContainer: nil)
         self.text = text
         var fontSize: CGFloat = 18
@@ -27,12 +30,12 @@ class MainText: UITextView {
         self.isSelectable = false
     }
 
-    func draw(parentVC: UIViewController, centerX: CGFloat, originY: CGFloat) {
+    func draw(centerX: CGFloat, originY: CGFloat) {
         self.frame.size.width = contentMaxWidth
         self.frame.size.height = self.contentSize.height
         self.center.x = centerX
         self.frame.origin.y = originY
-        parentVC.view.addSubview(self)
+        parentVC?.view.addSubview(self)
     }
 
     required init?(coder: NSCoder) {

--- a/COVIDWatch iOS/UIComponents/Menu.swift
+++ b/COVIDWatch iOS/UIComponents/Menu.swift
@@ -11,7 +11,7 @@ import UIKit
 let MANUAL_STATE_TEST = true
 
 class Menu: UIView {
-    weak var parentVC: BaseViewController?
+    weak var parentVC: BaseViewController!
     var xIcon = UIImageView(image: UIImage(named: "x-icon"))
     var menuItems: [MenuItem] = []
     var bottomWaterMark = UIImageView(image: UIImage(named: "collab-with-stanford"))
@@ -33,7 +33,7 @@ class Menu: UIView {
         self.backgroundColor = .white
         self.isHidden = true
         self.layer.zPosition = 1
-        parentVC?.view.addSubview(self)
+        parentVC.view.addSubview(self)
     }
 
     private func drawXIcon() {
@@ -47,7 +47,7 @@ class Menu: UIView {
         xIcon.isUserInteractionEnabled = true
         xIcon.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.toggleMenu)))
         xIcon.layer.zPosition = 1
-        parentVC?.view.addSubview(xIcon)
+        parentVC.view.addSubview(xIcon)
     }
 
     private func drawMenuItems() {
@@ -75,7 +75,7 @@ class Menu: UIView {
         bottomWaterMark.center.y = screenHeight - (69.5 * figmaToiOSVerticalScalingFactor)
         bottomWaterMark.isHidden = true
         bottomWaterMark.layer.zPosition = 1
-        parentVC?.view.addSubview(bottomWaterMark)
+        parentVC.view.addSubview(bottomWaterMark)
     }
 
     @objc func toggleMenu() {

--- a/COVIDWatch iOS/UIComponents/Menu.swift
+++ b/COVIDWatch iOS/UIComponents/Menu.swift
@@ -64,9 +64,7 @@ class Menu: UIView {
                 yCenter = lastYCenter + menuItemYGap
             }
             lastYCenter = yCenter
-            if let parentVC = self.parentVC {
-                item.draw(parentVC: parentVC, width: menuItemWidth, centerX: self.center.x, centerY: yCenter)
-            }
+            item.draw(width: menuItemWidth, centerX: self.center.x, centerY: yCenter)
         }
     }
 
@@ -95,33 +93,33 @@ class Menu: UIView {
         super.init(frame: CGRect())
         if !MANUAL_STATE_TEST {
             self.menuItems.append(contentsOf: [
-                MenuItem(text: "Settings", addLinkImg: true, onClick: {
+                MenuItem(parentVC, text: "Settings", addLinkImg: true, onClick: {
                     if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
                         UIApplication.shared.open(settingsURL)
                     }
                 }),
-                MenuItem(text: "Test Results", addLinkImg: false, onClick: {
+                MenuItem(parentVC, text: "Test Results", addLinkImg: false, onClick: {
                     if let parentVC = self.parentVC {
                         parentVC.performSegue(withIdentifier: "test", sender: parentVC)
                     }
                 }),
-                MenuItem(text: "How does this work?", addLinkImg: true, onClick: {
+                MenuItem(parentVC, text: "How does this work?", addLinkImg: true, onClick: {
                     print("Clicked How does this work?") // Dummy function for now
                 }),
-                MenuItem(text: "Covid Watch Website", addLinkImg: true, onClick: {
+                MenuItem(parentVC, text: "Covid Watch Website", addLinkImg: true, onClick: {
                     if let url = URL(string: "https://www.covid-watch.org/") {
                         UIApplication.shared.open(url)
                     }
                 }),
-                MenuItem(text: "Health Guidlines", addLinkImg: true, onClick: {
+                MenuItem(parentVC, text: "Health Guidlines", addLinkImg: true, onClick: {
                     if let url = URL(string: "https://www.cdc.gov/coronavirus/2019-nCoV/index.html") {
                         UIApplication.shared.open(url)
                     }
                 }),
-                MenuItem(text: "Terms of Use", addLinkImg: true, onClick: {
+                MenuItem(parentVC, text: "Terms of Use", addLinkImg: true, onClick: {
                     print("Clicked Terms of Use") // Dummy function for now
                 }),
-                MenuItem(text: "Privacy Policy", addLinkImg: true, onClick: {
+                MenuItem(parentVC, text: "Privacy Policy", addLinkImg: true, onClick: {
                     print("Clicked Privacy Policy") // Dummy function for now
                 })
             ])
@@ -132,31 +130,31 @@ class Menu: UIView {
             let threeDaysAgo = Calendar.current.date(byAdding: .day, value: -3, to: now)
             let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: now)
             self.menuItems.append(contentsOf: [
-                MenuItem(text: "mostRecentExposure-30d", addLinkImg: false, onClick: {
+                MenuItem(parentVC, text: "mostRecentExposure-30d", addLinkImg: false, onClick: {
                     globalState.mostRecentExposureDate = thirtyDaysAgo
                     print("Set mostRecentExposureDate to 30 days ago")
                 }),
-                MenuItem(text: "mostRecentExposure-3d", addLinkImg: false, onClick: {
+                MenuItem(parentVC, text: "mostRecentExposure-3d", addLinkImg: false, onClick: {
                     globalState.mostRecentExposureDate = threeDaysAgo
                     print("Set mostRecentExposureDate to 3 days ago")
                 }),
-                MenuItem(text: "mostRecentExposure-nil", addLinkImg: false, onClick: {
+                MenuItem(parentVC, text: "mostRecentExposure-nil", addLinkImg: false, onClick: {
                     globalState.mostRecentExposureDate = nil
                     print("Set mostRecentExposureDate to nil")
                 }),
-                MenuItem(text: "testLastSubmittedDate-30d", addLinkImg: false, onClick: {
+                MenuItem(parentVC, text: "testLastSubmittedDate-30d", addLinkImg: false, onClick: {
                     globalState.testLastSubmittedDate = thirtyDaysAgo
                     print("Set testLastSubmittedDate to 30 days ago")
                 }),
-                MenuItem(text: "testLastSubmittedDate-3d", addLinkImg: false, onClick: {
+                MenuItem(parentVC, text: "testLastSubmittedDate-3d", addLinkImg: false, onClick: {
                     globalState.testLastSubmittedDate = threeDaysAgo
                     print("Set testLastSubmittedDate to 3 days ago")
                 }),
-                MenuItem(text: "testLastSubmittedDate-nil", addLinkImg: false, onClick: {
+                MenuItem(parentVC, text: "testLastSubmittedDate-nil", addLinkImg: false, onClick: {
                     globalState.testLastSubmittedDate = nil
                     print("Set testLastSubmittedDate to nil")
                 }),
-                MenuItem(text: "Toggle isUserSick", addLinkImg: false, onClick: {
+                MenuItem(parentVC, text: "Toggle isUserSick", addLinkImg: false, onClick: {
                     globalState.isUserSick = !globalState.isUserSick
                     print("isUserSick set to \(globalState.isUserSick)")
                     // Enforce that global state is realistic

--- a/COVIDWatch iOS/UIComponents/MenuItem.swift
+++ b/COVIDWatch iOS/UIComponents/MenuItem.swift
@@ -9,15 +9,15 @@
 import UIKit
 
 class MenuItem: UIView {
-    let menuItem1 = UIView()
-    let menuItem1text = UILabel()
+    weak var parentVC: BaseViewController?
+    let text = UILabel()
     var linkImg: UIImageView?
     private var _onClick: () -> Void = {return}
-
+    
     // swiftlint:disable:next function_body_length
-    func draw(parentVC: UIViewController, width: CGFloat, centerX: CGFloat, centerY: CGFloat) {
-        menuItem1.isUserInteractionEnabled = true
-        menuItem1text.isUserInteractionEnabled = true
+    func draw(width: CGFloat, centerX: CGFloat, centerY: CGFloat) {
+        self.isUserInteractionEnabled = true
+        text.isUserInteractionEnabled = true
         linkImg?.isUserInteractionEnabled = true
         self.addGestureRecognizer(
             UITapGestureRecognizer(
@@ -25,13 +25,13 @@ class MenuItem: UIView {
                 action: #selector(self.onClick)
             )
         )
-        menuItem1.addGestureRecognizer(
+        self.addGestureRecognizer(
             UITapGestureRecognizer(
                 target: self,
                 action: #selector(self.onClick)
             )
         )
-        menuItem1text.addGestureRecognizer(
+        text.addGestureRecognizer(
             UITapGestureRecognizer(
                 target: self,
                 action: #selector(self.onClick)
@@ -43,58 +43,62 @@ class MenuItem: UIView {
                 action: #selector(self.onClick)
             )
         )
-        menuItem1.frame.size.width = width
-        menuItem1.center.x = centerX
-        menuItem1.center.y = centerY
-        menuItem1text.font = UIFont(name: "Montserrat-Bold", size: 18)
-        menuItem1text.textColor = UIColor(hexString: "585858")
-        menuItem1text.sizeToFit()
-        menuItem1text.frame.size.width = menuItem1.frame.size.width
-        menuItem1.frame.size.height = (38.0 * figmaToiOSVerticalScalingFactor)
-        menuItem1text.center = menuItem1.center
-        menuItem1text.layer.zPosition = 1
-        menuItem1.addLine(position: .bottom, color: UIColor(hexString: "CCCCCC"), width: 0.5)
+        self.frame.size.width = width
+        self.center.x = centerX
+        self.center.y = centerY
+        text.font = UIFont(name: "Montserrat-Bold", size: 18)
+        text.textColor = UIColor(hexString: "585858")
+        text.sizeToFit()
+        text.frame.size.width = self.frame.size.width
+        self.frame.size.height = (38.0 * figmaToiOSVerticalScalingFactor)
+        text.center = self.center
+        text.layer.zPosition = 1
+        self.addLine(position: .bottom, color: UIColor(hexString: "CCCCCC"), width: 0.5)
         if let linkImg = linkImg {
-            linkImg.frame.size.height = menuItem1text.frame.size.height
+            linkImg.frame.size.height = text.frame.size.height
             linkImg.frame.size.width = linkImg.frame.size.height
-            linkImg.center.y = menuItem1.center.y
-            linkImg.frame.origin.x = menuItem1.frame.maxX - linkImg.frame.size.width
+            linkImg.center.y = self.center.y
+            linkImg.frame.origin.x = self.frame.maxX - linkImg.frame.size.width
             linkImg.isHidden = true
         }
-        menuItem1text.isHidden = true
-        menuItem1.isHidden = true
+        text.isHidden = true
+        self.isHidden = true
         linkImg?.layer.zPosition = 1
-        menuItem1text.layer.zPosition = 1
-        menuItem1.layer.zPosition = 1
-
-        parentVC.view.addSubview(menuItem1)
-        parentVC.view.addSubview(menuItem1text)
+        text.layer.zPosition = 1
+        self.layer.zPosition = 1
+        
+        parentVC?.view.addSubview(self)
+        parentVC?.view.addSubview(text)
         if let linkImg = self.linkImg {
-            parentVC.view.addSubview(linkImg)
+            parentVC?.view.addSubview(linkImg)
         }
     }
-
+    
     func toggleShow() {
-        menuItem1.isHidden = !menuItem1.isHidden
-        menuItem1text.isHidden = !menuItem1text.isHidden
-        if let linkImg = self.linkImg {
+        self.isHidden = !self.isHidden
+        text.isHidden = !text.isHidden
+        if let linkImg = linkImg {
             linkImg.isHidden = !linkImg.isHidden
         }
     }
-
+    
     @objc func onClick() {
         self._onClick()
     }
-
-    init(text: String, addLinkImg: Bool = false, onClick: @escaping () -> Void) {
-        self.menuItem1text.text = text
+    
+    init(_ parentVC: BaseViewController,
+         text: String,
+         addLinkImg: Bool = false,
+         onClick: @escaping () -> Void) {
+        self.parentVC = parentVC
+        self.text.text = text
         if addLinkImg {
             linkImg = UIImageView(image: UIImage(named: "launch-symbol"))
         }
         self._onClick = onClick
         super.init(frame: CGRect())
     }
-
+    
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }

--- a/COVIDWatch iOS/UIComponents/MenuItem.swift
+++ b/COVIDWatch iOS/UIComponents/MenuItem.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class MenuItem: UIView {
-    weak var parentVC: BaseViewController?
+    weak var parentVC: BaseViewController!
     let text = UILabel()
     var linkImg: UIImageView?
     private var _onClick: () -> Void = {return}
@@ -67,10 +67,10 @@ class MenuItem: UIView {
         text.layer.zPosition = 1
         self.layer.zPosition = 1
         
-        parentVC?.view.addSubview(self)
-        parentVC?.view.addSubview(text)
+        parentVC.view.addSubview(self)
+        parentVC.view.addSubview(text)
         if let linkImg = self.linkImg {
-            parentVC?.view.addSubview(linkImg)
+            parentVC.view.addSubview(linkImg)
         }
     }
     

--- a/COVIDWatch iOS/ViewControllers/BaseViewController.swift
+++ b/COVIDWatch iOS/ViewControllers/BaseViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class BaseViewController: UIViewController {
-    var header: Header?
+    var header: Header!
 
     override func viewDidLoad() {
         self.header = Header(self)
@@ -21,12 +21,12 @@ class BaseViewController: UIViewController {
 //        Header must be drawn here instead of viewDidLoad(), because it makes use
 //        of view.safeAreaInsets.top which isn't filled out until this point in the
 //        ViewController life cycle.
-        self.header?.draw()
+        self.header.draw()
     }
 
     // Call this function at the end of child's viewDidLayoutSubviews() to draw the menu
     // with the items on top of everything else.
     func drawMenuOnTop() {
-        self.header?.menu?.draw()
+        self.header.menu?.draw()
     }
 }

--- a/COVIDWatch iOS/ViewControllers/BaseViewController.swift
+++ b/COVIDWatch iOS/ViewControllers/BaseViewController.swift
@@ -21,7 +21,7 @@ class BaseViewController: UIViewController {
 //        Header must be drawn here instead of viewDidLoad(), because it makes use
 //        of view.safeAreaInsets.top which isn't filled out until this point in the
 //        ViewController life cycle.
-        self.header?.draw(parentVC: self)
+        self.header?.draw()
     }
 
     // Call this function at the end of child's viewDidLayoutSubviews() to draw the menu

--- a/COVIDWatch iOS/ViewControllers/Bluetooth.swift
+++ b/COVIDWatch iOS/ViewControllers/Bluetooth.swift
@@ -91,15 +91,4 @@ class Bluetooth: BaseViewController {
             }
         }
     }
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/COVIDWatch iOS/ViewControllers/Bluetooth.swift
+++ b/COVIDWatch iOS/ViewControllers/Bluetooth.swift
@@ -13,11 +13,15 @@ class Bluetooth: BaseViewController {
     var largeText = LargeText(text: "Privately Connect")
     //swiftlint:disable:next line_length
     var mainText = MainText(text: "We use Bluetooth to anonymously log interactions with other Covid Watch users. Your personal data is always private and never shared.")
-    var button = Button(text: "Allow Bluetooth", subtext: "This is required for the app to work.")
-
+    var button: Button?
     var buttonRecognizer: UITapGestureRecognizer?
     var bluetoothPermission: BluetoothPermission?
-
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.button = Button(self, text: "Allow Bluetooth", subtext: "This is required for the app to work.")
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 //        Hide the Menu hamburger
@@ -44,10 +48,10 @@ class Bluetooth: BaseViewController {
         mainText.draw(parentVC: self, centerX: view.center.x, originY: largeText.frame.maxY)
         self.buttonRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.nextScreen))
         if let buttonRecognizer = self.buttonRecognizer {
-            self.button.addGestureRecognizer(buttonRecognizer)
+            self.button?.addGestureRecognizer(buttonRecognizer)
         }
         let buttonTop: CGFloat = 668.0 * figmaToiOSVerticalScalingFactor
-        button.draw(parentVC: self, centerX: view.center.x, originY: buttonTop)
+        button?.draw(centerX: view.center.x, originY: buttonTop)
     }
 
     @objc func nextScreen(sender: UITapGestureRecognizer) {

--- a/COVIDWatch iOS/ViewControllers/Bluetooth.swift
+++ b/COVIDWatch iOS/ViewControllers/Bluetooth.swift
@@ -10,9 +10,8 @@ import UIKit
 
 class Bluetooth: BaseViewController {
     var img = UIImageView(image: UIImage(named: "people-group-blue-2"))
-    var largeText = LargeText(text: "Privately Connect")
-    //swiftlint:disable:next line_length
-    var mainText = MainText(text: "We use Bluetooth to anonymously log interactions with other Covid Watch users. Your personal data is always private and never shared.")
+    var largeText: LargeText?
+    var mainText: MainText?
     var button: Button?
     var buttonRecognizer: UITapGestureRecognizer?
     var bluetoothPermission: BluetoothPermission?
@@ -20,6 +19,9 @@ class Bluetooth: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.button = Button(self, text: "Allow Bluetooth", subtext: "This is required for the app to work.")
+        //swiftlint:disable:next line_length
+        self.mainText = MainText(self, text: "We use Bluetooth to anonymously log interactions with other Covid Watch users. Your personal data is always private and never shared.")
+        self.largeText = LargeText(self, text: "Privately Connect")
     }
     
     override func viewDidLayoutSubviews() {
@@ -41,11 +43,10 @@ class Bluetooth: BaseViewController {
         }
         view.addSubview(img)
 
-        largeText.draw(parentVC: self,
-                       centerX: view.center.x,
+        largeText?.draw(centerX: view.center.x,
                        originY: img.frame.maxY + 20 * figmaToiOSVerticalScalingFactor)
 
-        mainText.draw(parentVC: self, centerX: view.center.x, originY: largeText.frame.maxY)
+        mainText?.draw(centerX: view.center.x, originY: largeText?.frame.maxY ?? 0)
         self.buttonRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.nextScreen))
         if let buttonRecognizer = self.buttonRecognizer {
             self.button?.addGestureRecognizer(buttonRecognizer)

--- a/COVIDWatch iOS/ViewControllers/Bluetooth.swift
+++ b/COVIDWatch iOS/ViewControllers/Bluetooth.swift
@@ -10,9 +10,9 @@ import UIKit
 
 class Bluetooth: BaseViewController {
     var img = UIImageView(image: UIImage(named: "people-group-blue-2"))
-    var largeText: LargeText?
-    var mainText: MainText?
-    var button: Button?
+    var largeText: LargeText!
+    var mainText: MainText!
+    var button: Button!
     var buttonRecognizer: UITapGestureRecognizer?
     var bluetoothPermission: BluetoothPermission?
     
@@ -27,7 +27,7 @@ class Bluetooth: BaseViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 //        Hide the Menu hamburger
-        self.header?.hasMenu = false
+        self.header.hasMenu = false
 
         self.view.backgroundColor = UIColor(hexString: "FFFFFF")
 
@@ -38,21 +38,19 @@ class Bluetooth: BaseViewController {
             img.frame.size.height /= 1.5
         }
         img.center.x = view.center.x
-        if let headerMinY = header?.frame.minY {
-            img.frame.origin.y = headerMinY + (119.0 * figmaToiOSVerticalScalingFactor)
-        }
+        img.frame.origin.y = header.frame.minY + (119.0 * figmaToiOSVerticalScalingFactor)
         view.addSubview(img)
 
-        largeText?.draw(centerX: view.center.x,
+        largeText.draw(centerX: view.center.x,
                        originY: img.frame.maxY + 20 * figmaToiOSVerticalScalingFactor)
 
-        mainText?.draw(centerX: view.center.x, originY: largeText?.frame.maxY ?? 0)
+        mainText.draw(centerX: view.center.x, originY: largeText.frame.maxY)
         self.buttonRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.nextScreen))
         if let buttonRecognizer = self.buttonRecognizer {
-            self.button?.addGestureRecognizer(buttonRecognizer)
+            self.button.addGestureRecognizer(buttonRecognizer)
         }
         let buttonTop: CGFloat = 668.0 * figmaToiOSVerticalScalingFactor
-        button?.draw(centerX: view.center.x, originY: buttonTop)
+        button.draw(centerX: view.center.x, originY: buttonTop)
     }
 
     @objc func nextScreen(sender: UITapGestureRecognizer) {

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -10,11 +10,11 @@ import UIKit
 
 class Home: BaseViewController {
     var img = UIImageView(image: UIImage(named: "woman-hero-blue-2"))
-    var largeText: LargeText?
-    var mainText: MainText?
-    var spreadButton: Button?
-    var testedButton: Button?
-    var infoBanner: InfoBanner?
+    var largeText: LargeText!
+    var mainText: MainText!
+    var spreadButton: Button!
+    var testedButton: Button!
+    var infoBanner: InfoBanner!
     var testLastSubmittedDateObserver: NSKeyValueObservation?
     var mostRecentExposureDateObserver: NSKeyValueObservation?
     var isUserSickObserver: NSKeyValueObservation?
@@ -165,19 +165,19 @@ class Home: BaseViewController {
         //        optionally draw the info banner and determine the coordinate for the top of the image
         var imgTop: CGFloat = 0
         if globalState.isUserAtRiskForCovid || globalState.isUserSick {
-            infoBanner?.isHidden = false
+            infoBanner.isHidden = false
             if globalState.isUserSick {
-                infoBanner?.isInteractive = false
-                infoBanner?.text.text = "You reported that you tested positive for COVID-19"
+                infoBanner.isInteractive = false
+                infoBanner.text.text = "You reported that you tested positive for COVID-19"
             } else {
-                infoBanner?.isInteractive = true
-                infoBanner?.text.text = "You may have been in contact with COVID-19"
+                infoBanner.isInteractive = true
+                infoBanner.text.text = "You may have been in contact with COVID-19"
             }
-            infoBanner?.draw(centerX: view.center.x, originY: header?.frame.maxY ?? 0)
-            imgTop = (infoBanner?.frame.maxY ?? 0) + 21.0 * figmaToiOSVerticalScalingFactor
+            infoBanner.draw(centerX: view.center.x, originY: header.frame.maxY)
+            imgTop = infoBanner.frame.maxY + 21.0 * figmaToiOSVerticalScalingFactor
         } else {
-            infoBanner?.isHidden = true
-            imgTop = header?.frame.maxY ?? 0
+            infoBanner.isHidden = true
+            imgTop = header.frame.maxY
         }
         //        determine image size
         img.frame.size.width = 253 * figmaToiOSHorizontalScalingFactor
@@ -192,72 +192,72 @@ class Home: BaseViewController {
         
         var mainTextTop: CGFloat
         if globalState.isFirstTimeUser {
-            largeText?.isHidden = false
-            largeText?.text = "You're all set!"
-            largeText?.draw(centerX: view.center.x,
+            largeText.isHidden = false
+            largeText.text = "You're all set!"
+            largeText.draw(centerX: view.center.x,
                             originY: img.frame.maxY + (22.0 * figmaToiOSVerticalScalingFactor))
-            mainTextTop = largeText?.frame.maxY ?? 0
+            mainTextTop = largeText.frame.maxY
         } else if !globalState.isUserAtRiskForCovid && !globalState.isUserSick {
-            largeText?.isHidden = false
-            largeText?.text = "Welcome Back!"
-            largeText?.draw(centerX: view.center.x,
+            largeText.isHidden = false
+            largeText.text = "Welcome Back!"
+            largeText.draw(centerX: view.center.x,
                             originY: img.frame.maxY + (22.0 * figmaToiOSVerticalScalingFactor))
-            mainTextTop = largeText?.frame.maxY ?? 0
+            mainTextTop = largeText.frame.maxY
         } else {
             //            userState.hasBeenInContact
-            largeText?.isHidden = true
+            largeText.isHidden = true
             mainTextTop = img.frame.maxY + 25.0 * figmaToiOSVerticalScalingFactor
         }
         
         //        draw mainText with respect to largeText or img or not at all
         if globalState.isFirstTimeUser {
             // swiftlint:disable:next line_length
-            mainText?.text = "Thank you for helping protect your communities. You will be notified of potential contact with COVID-19."
-            mainText?.draw(centerX: view.center.x, originY: mainTextTop)
+            mainText.text = "Thank you for helping protect your communities. You will be notified of potential contact with COVID-19."
+            mainText.draw(centerX: view.center.x, originY: mainTextTop)
         } else if !globalState.isUserAtRiskForCovid && !globalState.isUserSick {
             // swiftlint:disable:next line_length
-            mainText?.text = "Covid Watch has not detected exposure to COVID-19. Share the app with family and friends to help your community stay safe."
-            mainText?.draw(centerX: view.center.x, originY: mainTextTop)
+            mainText.text = "Covid Watch has not detected exposure to COVID-19. Share the app with family and friends to help your community stay safe."
+            mainText.draw(centerX: view.center.x, originY: mainTextTop)
         } else {
             //            userState.hasBeenInContact
-            mainText?.text = "Thank you for helping your community stay safe, anonymously."
-            mainText?.draw(centerX: view.center.x, originY: mainTextTop)
-            mainText?.textAlignment = .center
+            mainText.text = "Thank you for helping your community stay safe, anonymously."
+            mainText.draw(centerX: view.center.x, originY: mainTextTop)
+            mainText.textAlignment = .center
         }
         
         if globalState.isUserAtRiskForCovid || screenHeight <= 568 {
             //            Necessary to fit on screen
-            spreadButton?.subtext?.removeFromSuperview()
-            spreadButton?.subtext = nil
+            spreadButton.subtext?.removeFromSuperview()
+            spreadButton.subtext = nil
         } else {
             //            Clunky, but easier than messing with button internals
-            spreadButton?.text.removeFromSuperview()
-            spreadButton?.subtext?.removeFromSuperview()
-            spreadButton?.removeFromSuperview()
+            spreadButton.text.removeFromSuperview()
+            spreadButton.subtext?.removeFromSuperview()
+            spreadButton.removeFromSuperview()
             spreadButton = Button(self, text: "Share the app", subtext: "It works best when everyone uses it.")
         }
         //        spreadButton drawn below because its position depends on whether testedButton is drawn
-        spreadButton?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.share)))
+        spreadButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.share)))
         
         if globalState.isEligibleToSubmitTest {
-            self.testedButton?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.test)))
+            self.testedButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.test)))
             let testedButtonTop: CGFloat = 668.0 * figmaToiOSVerticalScalingFactor
-            testedButton?.draw(centerX: view.center.x, originY: testedButtonTop)
-            testedButton?.backgroundColor = .clear
-            testedButton?.layer.borderWidth = 1
-            testedButton?.layer.borderColor = UIColor.Secondary.LightGray.cgColor
-            testedButton?.text.textColor = UIColor.Primary.Gray
-            spreadButton?.drawBetween(top: mainText?.frame.maxY ?? 0,
+            testedButton.draw(centerX: view.center.x, originY: testedButtonTop)
+            testedButton.backgroundColor = .clear
+            testedButton.layer.borderWidth = 1
+            testedButton.layer.borderColor = UIColor.Secondary.LightGray.cgColor
+            testedButton.text.textColor = UIColor.Primary.Gray
+            spreadButton.drawBetween(top: mainText.frame.maxY,
                                       bottom: testedButtonTop,
                                       centerX: view.center.x)
-            testedButton?.isHidden = false
-            testedButton?.text.isHidden = false
-            testedButton?.subtext?.isHidden = false
+            testedButton.isHidden = false
+            testedButton.text.isHidden = false
+            testedButton.subtext?.isHidden = false
         } else {
-            testedButton?.isHidden = true
-            testedButton?.text.isHidden = true
-            testedButton?.subtext?.isHidden = true
-            spreadButton?.drawBetween(top: mainText?.frame.maxY ?? 0,
+            testedButton.isHidden = true
+            testedButton.text.isHidden = true
+            testedButton.subtext?.isHidden = true
+            spreadButton.drawBetween(top: mainText.frame.maxY,
                                       bottom: screenHeight - self.view.safeAreaInsets.bottom,
                                       centerX: view.center.x)
         }

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -10,9 +10,8 @@ import UIKit
 
 class Home: BaseViewController {
     var img = UIImageView(image: UIImage(named: "woman-hero-blue-2"))
-    var largeText = LargeText(text: "You're all set!")
-    //swiftlint:disable:next line_length
-    var mainText = MainText(text: "Thank you for helping protect your communities. You will be notified of potential contact with COVID-19.")
+    var largeText: LargeText?
+    var mainText: MainText?
     var spreadButton: Button?
     var testedButton: Button?
     var infoBanner: InfoBanner?
@@ -22,38 +21,40 @@ class Home: BaseViewController {
     var observer: NSObjectProtocol?
     var bluetoothPermission: BluetoothPermission?
     let globalState = UserDefaults.shared
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        spreadButton = Button(self, text: "Share the app", subtext: "It works best when everyone uses it.")
-        testedButton = Button(self, text: "Tested for COVID-19?",
-                              subtext: "Share your result anonymously to help keep your community stay safe.")
-        infoBanner = InfoBanner(self, text: "You may have been in contact with COVID-19", onClick: {
+        self.spreadButton = Button(self, text: "Share the app", subtext: "It works best when everyone uses it.")
+        self.testedButton = Button(self, text: "Tested for COVID-19?",
+                                   subtext: "Share your result anonymously to help keep your community stay safe.")
+        self.infoBanner = InfoBanner(self, text: "You may have been in contact with COVID-19", onClick: {
             self.performSegue(withIdentifier: "test", sender: self)
         })
+        //swiftlint:disable:next line_length
+        self.mainText = MainText(self, text: "Thank you for helping protect your communities. You will be notified of potential contact with COVID-19.")
+        self.largeText = LargeText(self, text: "You're all set!")
         
         testLastSubmittedDateObserver = globalState.observe(
             \.testLastSubmittedDate,
             options: [.initial, .new],
             changeHandler: { (_, _) in
-            self.drawScreen()
+                self.drawScreen()
         })
-
+        
         mostRecentExposureDateObserver = globalState.observe(
             \.mostRecentExposureDate,
             options: [],
             changeHandler: { (_, _) in
-            self.drawScreen()
+                self.drawScreen()
         })
-
+        
         isUserSickObserver = globalState.observe(
             \.isUserSick,
             options: [],
             changeHandler: { (_, _) in
-            self.drawScreen()
+                self.drawScreen()
         })
-
+        
         self.observer = NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,
             object: nil, queue: OperationQueue.main
@@ -62,23 +63,23 @@ class Home: BaseViewController {
         }
         self.checkNotificationPersmission()
     }
-
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         drawScreen()
         super.drawMenuOnTop()
     }
-
+    
     @objc func test() {
         self.performSegue(withIdentifier: "test", sender: self)
     }
-
+    
     // bluetooth and notification permissions
     enum AuthorizedPermissions {
         case bluetooth
         case notifications
     }
-
+    
     func checkNotificationPersmission(_ requiredPermissions: [AuthorizedPermissions] = []) {
         var morePermissions = requiredPermissions
         _ = NotificationPermission { [weak self] (result) in
@@ -92,7 +93,7 @@ class Home: BaseViewController {
             }
         }
     }
-
+    
     func checkBluetoothPermission(_ requiredPermissions: [AuthorizedPermissions] = []) {
         self.bluetoothPermission = BluetoothPermission { [weak self] (result) in
             var morePermissions = requiredPermissions
@@ -107,7 +108,7 @@ class Home: BaseViewController {
             }
         }
     }
-
+    
     func showPermissionsAlert(_ requiredPermissions: [AuthorizedPermissions] = []) {
         if requiredPermissions.count > 0 {
             var permissionTitle = "Permission Required"
@@ -124,7 +125,7 @@ class Home: BaseViewController {
                     }
                 }
             }
-
+            
             let permissionsAlert = UIAlertController(
                 title: NSLocalizedString(permissionTitle, comment: ""),
                 message: "Please turn on \(permissionText) in Settings", preferredStyle: .alert
@@ -137,31 +138,31 @@ class Home: BaseViewController {
                         if let url = URL(string: UIApplication.openSettingsURLString) {
                             UIApplication.shared.open(url)
                         }
-                    }
+                }
                 )
             )
             self.present(permissionsAlert, animated: true)
         }
     }
-
+    
     @objc func share() {
         // text to share
         let text = "Become a COVID Watcher and help your community stay safe."
         let url = NSURL(string: "https://www.covid-watch.org")
-
+        
         // set up activity view controller
         let itemsToShare: [Any] = [ text, url as Any ]
         let activityViewController = UIActivityViewController(activityItems: itemsToShare, applicationActivities: nil)
-
+        
         // so that iPads won't crash
         activityViewController.popoverPresentationController?.sourceView = self.view
-
+        
         // present the view controller
         self.present(activityViewController, animated: true, completion: nil)
     }
     // swiftlint:disable:next function_body_length
     private func drawScreen() {
-//        optionally draw the info banner and determine the coordinate for the top of the image
+        //        optionally draw the info banner and determine the coordinate for the top of the image
         var imgTop: CGFloat = 0
         if globalState.isUserAtRiskForCovid || globalState.isUserSick {
             infoBanner?.isHidden = false
@@ -178,7 +179,7 @@ class Home: BaseViewController {
             infoBanner?.isHidden = true
             imgTop = header?.frame.maxY ?? 0
         }
-//        determine image size
+        //        determine image size
         img.frame.size.width = 253 * figmaToiOSHorizontalScalingFactor
         img.frame.size.height = 259 * figmaToiOSVerticalScalingFactor
         if globalState.isFirstTimeUser && screenHeight <= 667 {
@@ -188,58 +189,56 @@ class Home: BaseViewController {
         img.center.x = view.center.x - 5 * figmaToiOSHorizontalScalingFactor
         img.frame.origin.y = imgTop
         self.view.addSubview(img)
-
+        
         var mainTextTop: CGFloat
         if globalState.isFirstTimeUser {
-            largeText.isHidden = false
-            largeText.text = "You're all set!"
-            largeText.draw(parentVC: self,
-            centerX: view.center.x,
-            originY: img.frame.maxY + (22.0 * figmaToiOSVerticalScalingFactor))
-            mainTextTop = largeText.frame.maxY
+            largeText?.isHidden = false
+            largeText?.text = "You're all set!"
+            largeText?.draw(centerX: view.center.x,
+                            originY: img.frame.maxY + (22.0 * figmaToiOSVerticalScalingFactor))
+            mainTextTop = largeText?.frame.maxY ?? 0
         } else if !globalState.isUserAtRiskForCovid && !globalState.isUserSick {
-            largeText.isHidden = false
-            largeText.text = "Welcome Back!"
-            largeText.draw(parentVC: self,
-            centerX: view.center.x,
-            originY: img.frame.maxY + (22.0 * figmaToiOSVerticalScalingFactor))
-            mainTextTop = largeText.frame.maxY
+            largeText?.isHidden = false
+            largeText?.text = "Welcome Back!"
+            largeText?.draw(centerX: view.center.x,
+                            originY: img.frame.maxY + (22.0 * figmaToiOSVerticalScalingFactor))
+            mainTextTop = largeText?.frame.maxY ?? 0
         } else {
-//            userState.hasBeenInContact
-            largeText.isHidden = true
+            //            userState.hasBeenInContact
+            largeText?.isHidden = true
             mainTextTop = img.frame.maxY + 25.0 * figmaToiOSVerticalScalingFactor
         }
-
-//        draw mainText with respect to largeText or img or not at all
+        
+        //        draw mainText with respect to largeText or img or not at all
         if globalState.isFirstTimeUser {
             // swiftlint:disable:next line_length
-            mainText.text = "Thank you for helping protect your communities. You will be notified of potential contact with COVID-19."
-            mainText.draw(parentVC: self, centerX: view.center.x, originY: mainTextTop)
+            mainText?.text = "Thank you for helping protect your communities. You will be notified of potential contact with COVID-19."
+            mainText?.draw(centerX: view.center.x, originY: mainTextTop)
         } else if !globalState.isUserAtRiskForCovid && !globalState.isUserSick {
             // swiftlint:disable:next line_length
-            mainText.text = "Covid Watch has not detected exposure to COVID-19. Share the app with family and friends to help your community stay safe."
-            mainText.draw(parentVC: self, centerX: view.center.x, originY: mainTextTop)
+            mainText?.text = "Covid Watch has not detected exposure to COVID-19. Share the app with family and friends to help your community stay safe."
+            mainText?.draw(centerX: view.center.x, originY: mainTextTop)
         } else {
-//            userState.hasBeenInContact
-            mainText.text = "Thank you for helping your community stay safe, anonymously."
-            mainText.draw(parentVC: self, centerX: view.center.x, originY: mainTextTop)
-            mainText.textAlignment = .center
+            //            userState.hasBeenInContact
+            mainText?.text = "Thank you for helping your community stay safe, anonymously."
+            mainText?.draw(centerX: view.center.x, originY: mainTextTop)
+            mainText?.textAlignment = .center
         }
-
+        
         if globalState.isUserAtRiskForCovid || screenHeight <= 568 {
-//            Necessary to fit on screen
+            //            Necessary to fit on screen
             spreadButton?.subtext?.removeFromSuperview()
             spreadButton?.subtext = nil
         } else {
-//            Clunky, but easier than messing with button internals
+            //            Clunky, but easier than messing with button internals
             spreadButton?.text.removeFromSuperview()
             spreadButton?.subtext?.removeFromSuperview()
             spreadButton?.removeFromSuperview()
             spreadButton = Button(self, text: "Share the app", subtext: "It works best when everyone uses it.")
         }
-//        spreadButton drawn below because its position depends on whether testedButton is drawn
+        //        spreadButton drawn below because its position depends on whether testedButton is drawn
         spreadButton?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.share)))
-
+        
         if globalState.isEligibleToSubmitTest {
             self.testedButton?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.test)))
             let testedButtonTop: CGFloat = 668.0 * figmaToiOSVerticalScalingFactor
@@ -248,9 +247,9 @@ class Home: BaseViewController {
             testedButton?.layer.borderWidth = 1
             testedButton?.layer.borderColor = UIColor.Secondary.LightGray.cgColor
             testedButton?.text.textColor = UIColor.Primary.Gray
-            spreadButton?.drawBetween(top: mainText.frame.maxY,
-                                     bottom: testedButtonTop,
-                                     centerX: view.center.x)
+            spreadButton?.drawBetween(top: mainText?.frame.maxY ?? 0,
+                                      bottom: testedButtonTop,
+                                      centerX: view.center.x)
             testedButton?.isHidden = false
             testedButton?.text.isHidden = false
             testedButton?.subtext?.isHidden = false
@@ -258,13 +257,13 @@ class Home: BaseViewController {
             testedButton?.isHidden = true
             testedButton?.text.isHidden = true
             testedButton?.subtext?.isHidden = true
-            spreadButton?.drawBetween(top: mainText.frame.maxY,
-                                     bottom: screenHeight - self.view.safeAreaInsets.bottom,
-                                     centerX: view.center.x)
+            spreadButton?.drawBetween(top: mainText?.frame.maxY ?? 0,
+                                      bottom: screenHeight - self.view.safeAreaInsets.bottom,
+                                      centerX: view.center.x)
         }
-
+        
         globalState.isFirstTimeUser = false
-
+        
     }
-
+    
 }

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -25,7 +25,7 @@ class Home: BaseViewController {
     let globalState = UserDefaults.shared
 
     override func viewDidLoad() {
-        infoBanner = InfoBanner(text: "You may have been in contact with COVID-19", onClick: {
+        infoBanner = InfoBanner(self, text: "You may have been in contact with COVID-19", onClick: {
             self.performSegue(withIdentifier: "test", sender: self)
         })
         super.viewDidLoad()
@@ -164,12 +164,12 @@ class Home: BaseViewController {
                 infoBanner.isHidden = false
                 if globalState.isUserSick {
                     infoBanner.isInteractive = false
-                    infoBanner.text?.text = "You reported that you tested positive for COVID-19"
+                    infoBanner.text.text = "You reported that you tested positive for COVID-19"
                 } else {
                     infoBanner.isInteractive = true
-                    infoBanner.text?.text = "You may have been in contact with COVID-19"
+                    infoBanner.text.text = "You may have been in contact with COVID-19"
                 }
-                infoBanner.draw(parentVC: self, centerX: view.center.x, originY: header?.frame.maxY ?? 0)
+                infoBanner.draw(centerX: view.center.x, originY: header?.frame.maxY ?? 0)
                 imgTop = infoBanner.frame.maxY + 21.0 * figmaToiOSVerticalScalingFactor
             } else {
                 infoBanner.isHidden = true

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -13,9 +13,8 @@ class Home: BaseViewController {
     var largeText = LargeText(text: "You're all set!")
     //swiftlint:disable:next line_length
     var mainText = MainText(text: "Thank you for helping protect your communities. You will be notified of potential contact with COVID-19.")
-    var spreadButton = Button(text: "Share the app", subtext: "It works best when everyone uses it.")
-    var testedButton = Button(text: "Tested for COVID-19?",
-                              subtext: "Share your result anonymously to help keep your community stay safe.")
+    var spreadButton: Button?
+    var testedButton: Button?
     var infoBanner: InfoBanner?
     var testLastSubmittedDateObserver: NSKeyValueObservation?
     var mostRecentExposureDateObserver: NSKeyValueObservation?
@@ -25,10 +24,15 @@ class Home: BaseViewController {
     let globalState = UserDefaults.shared
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        spreadButton = Button(self, text: "Share the app", subtext: "It works best when everyone uses it.")
+        testedButton = Button(self, text: "Tested for COVID-19?",
+                              subtext: "Share your result anonymously to help keep your community stay safe.")
         infoBanner = InfoBanner(self, text: "You may have been in contact with COVID-19", onClick: {
             self.performSegue(withIdentifier: "test", sender: self)
         })
-        super.viewDidLoad()
+        
         testLastSubmittedDateObserver = globalState.observe(
             \.testLastSubmittedDate,
             options: [.initial, .new],
@@ -159,22 +163,20 @@ class Home: BaseViewController {
     private func drawScreen() {
 //        optionally draw the info banner and determine the coordinate for the top of the image
         var imgTop: CGFloat = 0
-        if let infoBanner = self.infoBanner {
-            if globalState.isUserAtRiskForCovid || globalState.isUserSick {
-                infoBanner.isHidden = false
-                if globalState.isUserSick {
-                    infoBanner.isInteractive = false
-                    infoBanner.text.text = "You reported that you tested positive for COVID-19"
-                } else {
-                    infoBanner.isInteractive = true
-                    infoBanner.text.text = "You may have been in contact with COVID-19"
-                }
-                infoBanner.draw(centerX: view.center.x, originY: header?.frame.maxY ?? 0)
-                imgTop = infoBanner.frame.maxY + 21.0 * figmaToiOSVerticalScalingFactor
+        if globalState.isUserAtRiskForCovid || globalState.isUserSick {
+            infoBanner?.isHidden = false
+            if globalState.isUserSick {
+                infoBanner?.isInteractive = false
+                infoBanner?.text.text = "You reported that you tested positive for COVID-19"
             } else {
-                infoBanner.isHidden = true
-                imgTop = header?.frame.maxY ?? 0
+                infoBanner?.isInteractive = true
+                infoBanner?.text.text = "You may have been in contact with COVID-19"
             }
+            infoBanner?.draw(centerX: view.center.x, originY: header?.frame.maxY ?? 0)
+            imgTop = (infoBanner?.frame.maxY ?? 0) + 21.0 * figmaToiOSVerticalScalingFactor
+        } else {
+            infoBanner?.isHidden = true
+            imgTop = header?.frame.maxY ?? 0
         }
 //        determine image size
         img.frame.size.width = 253 * figmaToiOSHorizontalScalingFactor
@@ -226,39 +228,37 @@ class Home: BaseViewController {
 
         if globalState.isUserAtRiskForCovid || screenHeight <= 568 {
 //            Necessary to fit on screen
-            spreadButton.subtext?.removeFromSuperview()
-            spreadButton.subtext = nil
+            spreadButton?.subtext?.removeFromSuperview()
+            spreadButton?.subtext = nil
         } else {
 //            Clunky, but easier than messing with button internals
-            spreadButton.text.removeFromSuperview()
-            spreadButton.subtext?.removeFromSuperview()
-            spreadButton.removeFromSuperview()
-            spreadButton = Button(text: "Share the app", subtext: "It works best when everyone uses it.")
+            spreadButton?.text.removeFromSuperview()
+            spreadButton?.subtext?.removeFromSuperview()
+            spreadButton?.removeFromSuperview()
+            spreadButton = Button(self, text: "Share the app", subtext: "It works best when everyone uses it.")
         }
 //        spreadButton drawn below because its position depends on whether testedButton is drawn
-        spreadButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.share)))
+        spreadButton?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.share)))
 
         if globalState.isEligibleToSubmitTest {
-            self.testedButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.test)))
+            self.testedButton?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.test)))
             let testedButtonTop: CGFloat = 668.0 * figmaToiOSVerticalScalingFactor
-            testedButton.draw(parentVC: self, centerX: view.center.x, originY: testedButtonTop)
-            testedButton.backgroundColor = .clear
-            testedButton.layer.borderWidth = 1
-            testedButton.layer.borderColor = UIColor.Secondary.LightGray.cgColor
-            testedButton.text.textColor = UIColor.Primary.Gray
-            spreadButton.drawBetween(parentVC: self,
-                                     top: mainText.frame.maxY,
+            testedButton?.draw(centerX: view.center.x, originY: testedButtonTop)
+            testedButton?.backgroundColor = .clear
+            testedButton?.layer.borderWidth = 1
+            testedButton?.layer.borderColor = UIColor.Secondary.LightGray.cgColor
+            testedButton?.text.textColor = UIColor.Primary.Gray
+            spreadButton?.drawBetween(top: mainText.frame.maxY,
                                      bottom: testedButtonTop,
                                      centerX: view.center.x)
-            testedButton.isHidden = false
-            testedButton.text.isHidden = false
-            testedButton.subtext?.isHidden = false
+            testedButton?.isHidden = false
+            testedButton?.text.isHidden = false
+            testedButton?.subtext?.isHidden = false
         } else {
-            testedButton.isHidden = true
-            testedButton.text.isHidden = true
-            testedButton.subtext?.isHidden = true
-            spreadButton.drawBetween(parentVC: self,
-                                     top: mainText.frame.maxY,
+            testedButton?.isHidden = true
+            testedButton?.text.isHidden = true
+            testedButton?.subtext?.isHidden = true
+            spreadButton?.drawBetween(top: mainText.frame.maxY,
                                      bottom: screenHeight - self.view.safeAreaInsets.bottom,
                                      centerX: view.center.x)
         }

--- a/COVIDWatch iOS/ViewControllers/Home.swift
+++ b/COVIDWatch iOS/ViewControllers/Home.swift
@@ -36,7 +36,7 @@ class Home: BaseViewController {
         
         testLastSubmittedDateObserver = globalState.observe(
             \.testLastSubmittedDate,
-            options: [.initial, .new],
+            options: [],
             changeHandler: { (_, _) in
                 self.drawScreen()
         })

--- a/COVIDWatch iOS/ViewControllers/Notifications.swift
+++ b/COVIDWatch iOS/ViewControllers/Notifications.swift
@@ -10,15 +10,17 @@ import UIKit
 
 class Notifications: BaseViewController {
     var img = UIImageView(image: UIImage(named: "people-standing-01-blue-4"))
-    var largeText = LargeText(text: "Recieve Alerts")
-    //swiftlint:disable:next line_length
-    var mainText = MainText(text: "Enable notifications to receive anonymized alerts when you have come into contact with a confirmed case of COVID-19.")
+    var largeText: LargeText?
+    var mainText: MainText?
     var button: Button?
     var buttonRecognizer: UITapGestureRecognizer?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        button = Button(self, text: "Allow Notifications", subtext: nil)
+        self.button = Button(self, text: "Allow Notifications", subtext: nil)
+        //swiftlint:disable:next line_length
+        self.mainText = MainText(self, text: "Enable notifications to receive anonymized alerts when you have come into contact with a confirmed case of COVID-19.")
+        self.largeText = LargeText(self, text: "Recieve Alerts")
         NotificationCenter.default.addObserver(
             self, selector: #selector(nextScreenIfNotificationsEnabled),
             name: UIApplication.willEnterForegroundNotification, object: nil)
@@ -42,9 +44,9 @@ class Notifications: BaseViewController {
         view.addSubview(img)
 
         let imgToLargeTextGap = 40.0 * figmaToiOSVerticalScalingFactor
-        largeText.draw(parentVC: self, centerX: view.center.x, originY: img.frame.maxY + imgToLargeTextGap)
+        largeText?.draw(centerX: view.center.x, originY: img.frame.maxY + imgToLargeTextGap)
 
-        mainText.draw(parentVC: self, centerX: view.center.x, originY: largeText.frame.maxY)
+        mainText?.draw(centerX: view.center.x, originY: largeText?.frame.maxY ?? 0)
 
         self.buttonRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.nextScreen))
         if let buttonRecognizer = self.buttonRecognizer {

--- a/COVIDWatch iOS/ViewControllers/Notifications.swift
+++ b/COVIDWatch iOS/ViewControllers/Notifications.swift
@@ -10,9 +10,9 @@ import UIKit
 
 class Notifications: BaseViewController {
     var img = UIImageView(image: UIImage(named: "people-standing-01-blue-4"))
-    var largeText: LargeText?
-    var mainText: MainText?
-    var button: Button?
+    var largeText: LargeText!
+    var mainText: MainText!
+    var button: Button!
     var buttonRecognizer: UITapGestureRecognizer?
 
     override func viewDidLoad() {
@@ -29,7 +29,7 @@ class Notifications: BaseViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         //        Hide the Menu hamburger
-        self.header?.hasMenu = false
+        self.header.hasMenu = false
         self.view.backgroundColor = UIColor(hexString: "FFFFFF")
 
 //        Ratio is Figma image width to Figma screen width
@@ -40,21 +40,21 @@ class Notifications: BaseViewController {
             img.frame.size.height /= 1.5
         }
         img.center.x = view.center.x
-        img.frame.origin.y = (header?.frame.minY ?? 0) + (146.0 * figmaToiOSVerticalScalingFactor)
+        img.frame.origin.y = header.frame.minY + (146.0 * figmaToiOSVerticalScalingFactor)
         view.addSubview(img)
 
         let imgToLargeTextGap = 40.0 * figmaToiOSVerticalScalingFactor
-        largeText?.draw(centerX: view.center.x, originY: img.frame.maxY + imgToLargeTextGap)
+        largeText.draw(centerX: view.center.x, originY: img.frame.maxY + imgToLargeTextGap)
 
-        mainText?.draw(centerX: view.center.x, originY: largeText?.frame.maxY ?? 0)
+        mainText.draw(centerX: view.center.x, originY: largeText.frame.maxY)
 
         self.buttonRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.nextScreen))
         if let buttonRecognizer = self.buttonRecognizer {
-            self.button?.addGestureRecognizer(buttonRecognizer)
+            self.button.addGestureRecognizer(buttonRecognizer)
         }
 
         let buttonTop: CGFloat = 668.0 * figmaToiOSVerticalScalingFactor
-        button?.draw(centerX: view.center.x, originY: buttonTop)
+        button.draw(centerX: view.center.x, originY: buttonTop)
     }
 
     @objc func nextScreenIfNotificationsEnabled() {

--- a/COVIDWatch iOS/ViewControllers/Notifications.swift
+++ b/COVIDWatch iOS/ViewControllers/Notifications.swift
@@ -13,11 +13,12 @@ class Notifications: BaseViewController {
     var largeText = LargeText(text: "Recieve Alerts")
     //swiftlint:disable:next line_length
     var mainText = MainText(text: "Enable notifications to receive anonymized alerts when you have come into contact with a confirmed case of COVID-19.")
-    var button = Button(text: "Allow Notifications")
+    var button: Button?
     var buttonRecognizer: UITapGestureRecognizer?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        button = Button(self, text: "Allow Notifications", subtext: nil)
         NotificationCenter.default.addObserver(
             self, selector: #selector(nextScreenIfNotificationsEnabled),
             name: UIApplication.willEnterForegroundNotification, object: nil)
@@ -47,11 +48,11 @@ class Notifications: BaseViewController {
 
         self.buttonRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.nextScreen))
         if let buttonRecognizer = self.buttonRecognizer {
-            self.button.addGestureRecognizer(buttonRecognizer)
+            self.button?.addGestureRecognizer(buttonRecognizer)
         }
 
         let buttonTop: CGFloat = 668.0 * figmaToiOSVerticalScalingFactor
-        button.draw(parentVC: self, centerX: view.center.x, originY: buttonTop)
+        button?.draw(centerX: view.center.x, originY: buttonTop)
     }
 
     @objc func nextScreenIfNotificationsEnabled() {
@@ -101,15 +102,4 @@ class Notifications: BaseViewController {
             }
         }
     }
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }


### PR DESCRIPTION
I restructured all of the `UIComponents` so that they each get a weak reference to their `BaseViewController`, passed to them in their custom `init` functions.

I found that it was necessary to pass `Menu` its `parentVC` in its init function in order to allow it to pass `menuItem`s a function that performs a segue (see `Menu.swift:103`). I realized when I did that, that it was superfluous to keep passing the same `parentVC` in the `Menu.draw()` function, when i could just save a reference to it during `init`. This PR is enforcing that same design pattern for the rest of the `UIComponent`s.

The design makes sense because every `UIComponent` should have a corresponding parent `BaseViewController` on initialization. Unfortunately, the
```swift
required init?(coder: NSCoder) {
        super.init(coder: coder)
    }
```
demanded by all `UIResponder`s (i.e. `UIView`, `UIViewController`, etc) really threw off all my attempts at writing elegant custom `init` functions to set up all the `ViewController`s with their default `UIComponent`s. Instead, I'm forced to make the `UIComponents` optional, initialize them in the `viewDidLoad`, and then force unwrap them everywhere they're called after `viewDidLoad`. Because this force unwrapping is intentional I made the optionals all "auto-force-unwrap" (by appending their type with `!` instead of `?`; i.e. `var button: Button!`).