### PR TITLE
Adding Dev ref to git to fix merge

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -15,6 +15,7 @@ jobs:
         fetch-depth: 0
     - name: Merge Dev into Master
       run: |
+        git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules origin +refs/heads/dev
         git checkout dev 
         git pull
         git checkout master


### PR DESCRIPTION
I needed to add a ref to the dev branch to git to fix checking out dev during the merge to master.

<img width="570" alt="Screen Shot 2020-04-21 at 5 55 37 AM" src="https://user-images.githubusercontent.com/2142301/79852718-07a76c80-8395-11ea-86b7-39f808cf3220.png">
