### PR TITLE
Moving build command to fastlane and removing swiftlint CI step

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,16 +16,16 @@ jobs:
           bundle install
       - name: Xcode Build
         run: |
-          set -o pipefail
           bundle exec fastlane build
 
   test:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Run Tests
+      - name: Install Dependencies
         run: |
-          set -o pipefail
           gem install bundler:1.16.6
           bundle install
+      - name: Run Tests
+        run: |
           bundle exec fastlane tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,15 +17,7 @@ jobs:
       - name: Xcode Build
         run: |
           set -o pipefail
-          xcodebuild build -workspace COVIDWatch.xcworkspace -scheme 'covidwatch-ios-dev' CODE_SIGNING_ALLOWED=NO | xcpretty
-
-  swiftlint:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: SwiftLint
-        run: |
-          ./Pods/SwiftLint/swiftlint --strict
+          bundle exec fastlane build
 
   test:
     runs-on: macos-latest

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,6 +16,7 @@
 default_platform(:ios)
 
 platform :ios do
+
   desc "Push a new beta build to TestFlight"
   lane :beta do
     setup_ci(provider: "travis")
@@ -25,11 +26,18 @@ platform :ios do
     build_app(workspace: "COVIDWatch.xcworkspace", scheme: "covidwatch-ios-prod")
     testflight(apple_id: "1504929027", distribute_external: true, groups: ["Public Link"], changelog: "Daily Beta for " + Date.today.to_s)
   end
-end
 
-lane :tests do
-  run_tests(workspace: "COVIDWatch.xcworkspace",
-            devices: ["iPhone 11"],
-            reinstall_app: true,
-            scheme: "covidwatch-ios-test")
+  desc "Run UI and Unit Tests"
+  lane :tests do
+    run_tests(workspace: "COVIDWatch.xcworkspace",
+              devices: ["iPhone 11"],
+              reinstall_app: true,
+              scheme: "covidwatch-ios-test")
+  end
+
+  desc "Build Only"
+  lane :build do
+    build_app(workspace: "COVIDWatch.xcworkspace", scheme: "covidwatch-ios-dev", skip_codesigning: true, skip_archive: true)
+  end
+
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,44 +1,38 @@
-# fastlane
-
-## Installation
+fastlane documentation
+================
+# Installation
 
 Make sure you have the latest version of the Xcode command line tools installed:
 
 ```
-$ xcode-select --install
+xcode-select --install
 ```
 
 Install _fastlane_ using
-
 ```
-$ [sudo] gem install fastlane -NV
+[sudo] gem install fastlane -NV
 ```
+or alternatively using `brew cask install fastlane`
 
-or alternatively using brew:
-
+# Available Actions
+## iOS
+### ios beta
 ```
-$ brew cask install fastlane
+fastlane ios beta
 ```
-
-## Available Actions
-
-### Tests
-
-```
-$ fastlane tests
-```
-
----
-
-### iOS Beta
-
-```
-$ fastlane ios beta
-```
-
 Push a new beta build to TestFlight
+### ios tests
+```
+fastlane ios tests
+```
+Run UI and Unit Tests
+### ios build
+```
+fastlane ios build
+```
+Build Only
 
----
+----
 
 This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).


### PR DESCRIPTION
Now that we added the strict parameter to the swifflint build phase, the build will fail from warnings.  So we don't really need a separate CI step for SwiftLint anymore.