### PR TITLE
Lint Improvements

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,3 +29,15 @@ jobs:
       - name: Run Tests
         run: |
           bundle exec fastlane tests
+
+  lint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: |
+          gem install bundler:1.16.6
+          bundle install
+      - name: Run Lint
+        run: |
+          bundle exec fastlane ios lint

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
-excluded: # paths to ignore during linting. Takes precedence over `included`.
-  - Carthage
-  - Pods
+included:
+  - "CovidWatch iOS"
+  - "CovidWatch iOSTests"
+  - "CovidWatch iOSUITests"
 
 identifier_name:
   allowed_symbols: "_"
@@ -12,7 +13,7 @@ identifier_name:
   excluded:
     - id
 
-enabled_rules:
+opt_in_rules:
   - force_unwrapping
 
 disabled_rules:

--- a/CovidWatch.xcodeproj/project.pbxproj
+++ b/CovidWatch.xcodeproj/project.pbxproj
@@ -770,7 +770,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${PODS_ROOT}/SwiftLint/swiftlint --strict\n";
+			shellScript = "${SRCROOT}/scripts/run_swiftlint.sh\n";
 		};
 		FC6303ED284885D616B54BE3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Scripts/run_swiftlint.sh
+++ b/Scripts/run_swiftlint.sh
@@ -1,0 +1,16 @@
+#!/bin/zsh
+
+# check to make sure were in the right directory, print error if not found,
+# this is intentionally not using any Xcode build variables
+# so that it can be run locally for debugging from the repo root.
+[ -d "CovidWatch iOS" ] || echo "error: No 'CovidWatch iOS' directory found. Are you running this from the repo root?"
+
+# github actions are run as runner
+if [[ "$USER" == "runner" ]]
+then
+    echo "warning: CI system detected - skipping swiftlint"
+else
+    Pods/SwiftLint/swiftlint --strict --config .swiftlint.yml
+fi
+
+

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,4 +40,8 @@ platform :ios do
     build_app(workspace: "COVIDWatch.xcworkspace", scheme: "covidwatch-ios-dev", skip_codesigning: true, skip_archive: true)
   end
 
+  desc "SwiftLint"
+  lane :lint do
+    swiftlint(executable: 'Pods/SwiftLint/swiftlint', strict: true)
+  end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,6 +31,11 @@ Run UI and Unit Tests
 fastlane ios build
 ```
 Build Only
+### ios lint
+```
+fastlane ios lint
+```
+SwiftLint
 
 ----
 


### PR DESCRIPTION
This change was motivated by [this PR comment](https://github.com/covid19risk/covidwatch-ios/pull/104#issuecomment-619323843) and intends to make our SwiftLint integration more developer friendly.

Changes:

1. The SwiftLint build phase wasn't printing helpful output when building in CI via fastlane, so this PR disables that build phase in CI but keeps it running locally.  It does this by checking for the current user and skips SwiftLint if the user is 'runner', which is what user GitHub actions are run with.  It will also print a build warning if SwiftLint is skipped:

<img width="596" alt="Screen Shot 2020-04-25 at 8 17 45 AM" src="https://user-images.githubusercontent.com/2142301/80280131-24fb7400-86d0-11ea-9cf3-7d224ae56b2b.png">

If we mess this integration up later and we're not running SwiftLint locally - we'll know because this warning will show up in Xcode.

2. I also thought it would be easier to code review the shell code in a .sh file instead of the build phase, so its contents aren't jumbled up into 1 line.  I then added comments to the shell script.

3. Now that SwiftLint is not running in our build phase during CI, I added back a separate lint step in our pull request workflow.  It is using fastlane so that it will print the output properly if there are warnings or errors.

I added a test swifflint error temporarily to be able to test this.  [This is what we can expect now for SwiftLint errors.](https://github.com/covid19risk/covidwatch-ios/actions/runs/87555728)

